### PR TITLE
CRD validation for either portal url or embedded config

### DIFF
--- a/deploy/crds/apps_v1alpha1_apicast_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_apicast_crd.yaml
@@ -80,6 +80,15 @@ spec:
             serviceAccount:
               type: string
           type: object
+          anyOf:
+           - properties:
+               adminPortalCredentialsRef:
+                 type: object
+               required: ["adminPortalCredentialsRef"]
+           - properties:
+               embeddedConfigurationSecretRef:
+                 type: object
+               required: ["embeddedConfigurationSecretRef"]
         status:
           properties:
             conditions:


### PR DESCRIPTION
With this conditional subschema validation, we are enforcing at CRD level, i.e. at kubernetes cluster level, that either one or the other of the possible configuration sources exist.

The alternative is doing at operator level.

Both solutions have tradeoffs. Basically, enforcing at k8s level saves your operator code to  implement the validation and the user will notice the validation failure when using CLI kubectl. On the other hand, validating at the operator level gives more flexibility for future updates and avoid updating CRD with breaking changes in backwards compatibility.

Openapi v3 structural schema is flexible enough to add some other conditional validations. For instance, as non sense example but helps illustrating, you may have another conditional subschema to say, `anyOf` `image` or `logLevel` should be present like this:

```yaml
anyOf:                                            
  - properties:                                   
      adminPortalCredentialsRef:                  
        type: object                              
    required: ["adminPortalCredentialsRef"]       
  - properties:                                   
      embeddedConfigurationSecretRef:             
        type: object                              
    required: ["embeddedConfigurationSecretRef"]  
anyOf:                                            
  - properties:                                   
      image:                                      
        type: string                              
    required: ["image"]                           
  - properties:                                   
      logLevel:                                   
        type: string                              
    required: ["logLevel"]                        
```
