### PR TITLE
Add needed missing operator role permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -26,6 +26,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - '*'
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors


### PR DESCRIPTION
Additional permissions for managing ingresses are needed when deploying the operator in a cluster using the role file