### PR TITLE
Fix settings defaults for image and accountservice

### DIFF
--- a/pkg/controller/apicast/apicast_logic_reconciler.go
+++ b/pkg/controller/apicast/apicast_logic_reconciler.go
@@ -317,14 +317,24 @@ func (r *APIcastLogicReconciler) internalAPIcast(userProvidedSecrets *apicastUse
 		gatewayConfigurationSecretName = &tmpGatewayConfigurationSecretName
 	}
 
+	image := apicast.GetDefaultImageVersion()
+	if r.APIcastCR.Spec.Image != nil {
+		image = *r.APIcastCR.Spec.Image
+	}
+
+	serviceAccount := "default"
+	if r.APIcastCR.Spec.ServiceAccount != nil {
+		serviceAccount = *r.APIcastCR.Spec.ServiceAccount
+	}
+
 	apicastResult := apicast.APIcast{
 		DeploymentName:                   apicastFullName,
 		ServiceName:                      apicastFullName,
 		Replicas:                         int32(*r.APIcastCR.Spec.Replicas),
 		AppLabel:                         "apicast",
 		AdditionalAnnotations:            deploymentAnnotations,
-		ServiceAccountName:               *r.APIcastCR.Spec.ServiceAccount,
-		Image:                            *r.APIcastCR.Spec.Image,
+		ServiceAccountName:               serviceAccount,
+		Image:                            image,
 		ExposedHost:                      apicastExposedHost,
 		Namespace:                        r.APIcastCR.Namespace,
 		OwnerReference:                   &apicastOwnerRef,
@@ -367,20 +377,10 @@ func (r *APIcastLogicReconciler) initialize() (bool, error) {
 
 func (r *APIcastLogicReconciler) applyInitialization() bool {
 	var defaultAPIcastReplicas int64 = 1
-	defaultServiceAccount := "default"
-	defaultAPIcastImage := apicast.GetDefaultImageVersion()
 	appliedInitialization := false
 
 	if r.APIcastCR.Spec.Replicas == nil {
 		r.APIcastCR.Spec.Replicas = &defaultAPIcastReplicas
-		appliedInitialization = true
-	}
-	if r.APIcastCR.Spec.ServiceAccount == nil {
-		r.APIcastCR.Spec.ServiceAccount = &defaultServiceAccount
-		appliedInitialization = true
-	}
-	if r.APIcastCR.Spec.Image == nil {
-		r.APIcastCR.Spec.Image = &defaultAPIcastImage
 		appliedInitialization = true
 	}
 


### PR DESCRIPTION
It does not make sense to set defaults on some fields at the custom resource. If the operator sets some default in the custom resource, on future reconciliation runs there is no way to know if the value has been set by the user or not. This procedure can be useful for some fields, as the user can see what defaults are being used. But, on the other hand, it can entirely disable upgrading mechanism for some cases, for instance, when that field is the image url of the product.

The operator cannot change the desired state and if image is part of the desired state, upgrading cannot be performed. And the operator does not have any way of knowing if the value has been set as default value or has been set by the user.

Setting defaults has other drawback, as the operator cannot change them (because they are wrong or outdated or whatever) when operator is upgraded. Once the defaults are written to the CR, those values are no longer default values, but desired values.

ServiceAccount name's default value was removed from the CR for that reason.