### PR TITLE
Makefile: use current Kubernetes namespace for commands that use the NAMESPACE variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ vendor:
 IMAGE ?= quay.io/3scale/apicast-operator
 SOURCE_VERSION ?= master
 VERSION ?= v0.0.1
-NAMESPACE ?= operator-test
+NAMESPACE ?= $(shell kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}' 2>/dev/null || echo operator-test)
 OPERATOR_NAME ?= apicast-operator
 
 ## build: Build operator


### PR DESCRIPTION
Examples:

```
msoriano@localhost:~/go/src/github.com/3scale/apicast-operator (makefile-set-current-namespace)$ oc project
Using project "anamespace" on server "https://192.168.99.100:8443".
msoriano@localhost:~/go/src/github.com/3scale/apicast-operator (makefile-set-current-namespace)$ make local
OPERATOR_NAME=apicast-operator operator-sdk up local --namespace anamespace
INFO[0000] Running the operator locally.                
INFO[0000] Using namespace anamespace.                  
^Cmake: *** [Makefile:49: local] Interrupt

msoriano@localhost:~/go/src/github.com/3scale/apicast-operator (makefile-set-current-namespace)$ oc project aproject
Now using project "aproject" on server "https://192.168.99.100:8443".
msoriano@localhost:~/go/src/github.com/3scale/apicast-operator (makefile-set-current-namespace)$ oc project
Using project "aproject" on server "https://192.168.99.100:8443".
msoriano@localhost:~/go/src/github.com/3scale/apicast-operator (makefile-set-current-namespace)$ make local
OPERATOR_NAME=apicast-operator operator-sdk up local --namespace aproject
INFO[0000] Running the operator locally.                
INFO[0000] Using namespace aproject.                    
^Cmake: *** [Makefile:49: local] Interrupt
```
