### PR TITLE
Fix openshift custom host role

### DIFF
--- a/deploy/olm-catalog/apicast-operator/0.0.0/apicast-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/apicast-operator/0.0.0/apicast-operator.v0.0.0.clusterserviceversion.yaml
@@ -213,6 +213,12 @@ spec:
           - routes/custom-host
           verbs:
           - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: apicast-operator
     strategy: deployment
   installModes:

--- a/deploy/olm-catalog/apicast-operator/0.0.0/apicast-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/apicast-operator/0.0.0/apicast-operator.v0.0.0.clusterserviceversion.yaml
@@ -207,6 +207,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
         serviceAccountName: apicast-operator
     strategy: deployment
   installModes:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -90,3 +90,10 @@ rules:
   - patch
   - update
   - watch
+# Openshift support
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -97,3 +97,9 @@ rules:
   - routes/custom-host
   verbs:
   - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
Add role rule `routes.route.openshift.io/custom-host` to support OCP. Does not affect k8s eventhough it is "openshift" related role. 

Tested on:
* k8s 1.14.10
* OCP 4.2

An alternative option would be maintain operator metadata different for k8s and OCP "flavors".

The motivation for this change is that when creating an Ingress with an IngressRule that has the 'host' field set in an OpenShift environment the following error is shown:
```
{"level":"error","ts":1585080246.091675,"logger":"controller_apicast","msg":"Requeuing request...","error":"ingresses.extensions \"apicast-apicast-stage\" is invalid: spec.rules[0]: Forbidden: you do not have permission to set host fields in ingress rules
```