### PR TITLE
contextual logging

### DIFF
--- a/pkg/reconcilers/base_controller_reconciler.go
+++ b/pkg/reconcilers/base_controller_reconciler.go
@@ -1,16 +1,27 @@
 package reconcilers
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type BaseControllerReconciler struct {
-	BaseReconciler
+	// client should be a split client that reads objects from
+	// the cache and writes to the Kubernetes APIServer
+	client client.Client
+	// apiClientReader should be a client that directly reads objects
+	// from the Kubernetes APIServer
+	apiClientReader client.Reader
+	//
+	scheme *runtime.Scheme
 }
 
-func NewBaseControllerReconciler(b BaseReconciler) BaseControllerReconciler {
+func NewBaseControllerReconciler(client client.Client, apiClientReader client.Reader, scheme *runtime.Scheme) BaseControllerReconciler {
 	return BaseControllerReconciler{
-		BaseReconciler: b,
+		client:          client,
+		apiClientReader: apiClientReader,
+		scheme:          scheme,
 	}
 }
 
@@ -19,4 +30,16 @@ var _ reconcile.Reconciler = &BaseControllerReconciler{}
 
 func (r *BaseControllerReconciler) Reconcile(reconcile.Request) (reconcile.Result, error) {
 	return reconcile.Result{}, nil
+}
+
+func (r *BaseControllerReconciler) Client() client.Client {
+	return r.client
+}
+
+func (r *BaseControllerReconciler) APIClientReader() client.Reader {
+	return r.apiClientReader
+}
+
+func (r *BaseControllerReconciler) Scheme() *runtime.Scheme {
+	return r.scheme
 }


### PR DESCRIPTION
Apicast operator supports multiple apicast instances. This PR adds  context about the apicast instance the log related to (CR name and namespace)

Note that the baseController's logger instance will be contextualized to the apicast instance. 