### PR TITLE
Update deprecated CircleCI images 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
 
   tag-operator-image-master:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -236,7 +236,7 @@ jobs:
 
   tag-operator-image-release:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -283,7 +283,7 @@ jobs:
 
   run-openshift-e2e-test:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/go/src/github.com/3scale/apicast-operator


### PR DESCRIPTION
As per https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572, some linux machine images have been deprecated in CircleCI

This PR updates the deprecated circleci/classic:latest images by ubuntu-1604:202007-01 as suggested in the provided link. There's also an ubuntu 20 based image but is still in beta so we are not using it yet.

The update of image implies an update of operating system from Ubuntu 14.04 to Ubuntu 16.04.