### PR TITLE
Update CustomResourceDefinition API version to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/3scale/apicast-operator:master
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+
+CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/bundle/manifests/apps.3scale.net_apicasts.yaml
+++ b/bundle/manifests/apps.3scale.net_apicasts.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,222 +15,221 @@ spec:
     plural: apicasts
     singular: apicast
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: APIcast is the Schema for the apicasts API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          anyOf:
-          - required:
-            - adminPortalCredentialsRef
-          - required:
-            - embeddedConfigurationSecretRef
-          description: APIcastSpec defines the desired state of APIcast
-          properties:
-            adminPortalCredentialsRef:
-              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            cacheConfigurationSeconds:
-              format: int64
-              type: integer
-            cacheMaxTime:
-              description: CacheMaxTime indicates the maximum time to be cached. If cache-control header is not set, the time to be cached will be the defined one.
-              type: string
-            cacheStatusCodes:
-              description: CacheStatusCodes defines the status codes for which the response content will be cached.
-              type: string
-            configurationLoadMode:
-              enum:
-              - boot
-              - lazy
-              type: string
-            deploymentEnvironment:
-              type: string
-            dnsResolverAddress:
-              type: string
-            embeddedConfigurationSecretRef:
-              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            enabledServices:
-              items:
-                type: string
-              type: array
-            exposedHost:
-              properties:
-                host:
-                  type: string
-                tls:
-                  items:
-                    description: IngressTLS describes the transport layer security associated with an Ingress.
-                    properties:
-                      hosts:
-                        description: Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
-                        items:
-                          type: string
-                        type: array
-                      secretName:
-                        description: SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - host
-              type: object
-            httpsCertificateSecretRef:
-              description: HTTPSCertificateSecretRef references secret containing the X.509 certificate in the PEM format and the X.509 certificate secret key.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            httpsPort:
-              description: HttpsPort controls on which port APIcast should start listening for HTTPS connections. If this clashes with HTTP port it will be used only for HTTPS.
-              format: int32
-              type: integer
-            httpsVerifyDepth:
-              description: HTTPSVerifyDepth defines the maximum length of the client certificate chain.
-              format: int64
-              minimum: 0
-              type: integer
-            image:
-              type: string
-            loadServicesWhenNeeded:
-              description: LoadServicesWhenNeeded makes the configurations to be loaded lazily. APIcast will only load the ones configured for the host specified in the host header of the request.
-              type: boolean
-            logLevel:
-              enum:
-              - debug
-              - info
-              - notice
-              - warn
-              - error
-              - crit
-              - alert
-              - emerg
-              type: string
-            managementAPIScope:
-              enum:
-              - disabled
-              - status
-              - policies
-              - debug
-              type: string
-            oidcLogLevel:
-              description: OidcLogLevel allows to set the log level for the logs related to OpenID Connect integration.
-              enum:
-              - debug
-              - info
-              - notice
-              - warn
-              - error
-              - crit
-              - alert
-              - emerg
-              type: string
-            openSSLPeerVerificationEnabled:
-              type: boolean
-            pathRoutingEnabled:
-              type: boolean
-            replicas:
-              format: int64
-              type: integer
-            resources:
-              description: ResourceRequirements describes the compute resource requirements.
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            responseCodesIncluded:
-              type: boolean
-            serviceAccount:
-              type: string
-            serviceConfigurationVersionOverride:
-              additionalProperties:
-                type: string
-              description: ServiceConfigurationVersionOverride contains service configuration version map to prevent it from auto-updating.
-              type: object
-            servicesFilterByURL:
-              description: ServicesFilterByURL is used to filter the service configured in the 3scale API Manager, the filter matches with the public base URL (Staging or production).
-              type: string
-            upstreamRetryCases:
-              description: UpstreamRetryCases Used only when the retry policy is configured. Specified in which cases a request to the upstream API should be retried.
-              enum:
-              - error
-              - timeout
-              - invalid_header
-              - http_500
-              - http_502
-              - http_503
-              - http_504
-              - http_403
-              - http_404
-              - http_429
-              - non_idempotent
-              - "off"
-              type: string
-          type: object
-        status:
-          description: APIcastStatus defines the observed state of APIcast
-          properties:
-            conditions:
-              description: Represents the latest available observations of a replica set's current state.
-              items:
-                properties:
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of replica set condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            image:
-              description: The image being used in the APIcast deployment
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: APIcast is the Schema for the apicasts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            anyOf:
+            - required:
+              - adminPortalCredentialsRef
+            - required:
+              - embeddedConfigurationSecretRef
+            description: APIcastSpec defines the desired state of APIcast
+            properties:
+              adminPortalCredentialsRef:
+                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              cacheConfigurationSeconds:
+                format: int64
+                type: integer
+              cacheMaxTime:
+                description: CacheMaxTime indicates the maximum time to be cached. If cache-control header is not set, the time to be cached will be the defined one.
+                type: string
+              cacheStatusCodes:
+                description: CacheStatusCodes defines the status codes for which the response content will be cached.
+                type: string
+              configurationLoadMode:
+                enum:
+                - boot
+                - lazy
+                type: string
+              deploymentEnvironment:
+                type: string
+              dnsResolverAddress:
+                type: string
+              embeddedConfigurationSecretRef:
+                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              enabledServices:
+                items:
+                  type: string
+                type: array
+              exposedHost:
+                properties:
+                  host:
+                    type: string
+                  tls:
+                    items:
+                      description: IngressTLS describes the transport layer security associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+                          items:
+                            type: string
+                          type: array
+                        secretName:
+                          description: SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - host
+                type: object
+              httpsCertificateSecretRef:
+                description: HTTPSCertificateSecretRef references secret containing the X.509 certificate in the PEM format and the X.509 certificate secret key.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              httpsPort:
+                description: HttpsPort controls on which port APIcast should start listening for HTTPS connections. If this clashes with HTTP port it will be used only for HTTPS.
+                format: int32
+                type: integer
+              httpsVerifyDepth:
+                description: HTTPSVerifyDepth defines the maximum length of the client certificate chain.
+                format: int64
+                minimum: 0
+                type: integer
+              image:
+                type: string
+              loadServicesWhenNeeded:
+                description: LoadServicesWhenNeeded makes the configurations to be loaded lazily. APIcast will only load the ones configured for the host specified in the host header of the request.
+                type: boolean
+              logLevel:
+                enum:
+                - debug
+                - info
+                - notice
+                - warn
+                - error
+                - crit
+                - alert
+                - emerg
+                type: string
+              managementAPIScope:
+                enum:
+                - disabled
+                - status
+                - policies
+                - debug
+                type: string
+              oidcLogLevel:
+                description: OidcLogLevel allows to set the log level for the logs related to OpenID Connect integration.
+                enum:
+                - debug
+                - info
+                - notice
+                - warn
+                - error
+                - crit
+                - alert
+                - emerg
+                type: string
+              openSSLPeerVerificationEnabled:
+                type: boolean
+              pathRoutingEnabled:
+                type: boolean
+              replicas:
+                format: int64
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              responseCodesIncluded:
+                type: boolean
+              serviceAccount:
+                type: string
+              serviceConfigurationVersionOverride:
+                additionalProperties:
+                  type: string
+                description: ServiceConfigurationVersionOverride contains service configuration version map to prevent it from auto-updating.
+                type: object
+              servicesFilterByURL:
+                description: ServicesFilterByURL is used to filter the service configured in the 3scale API Manager, the filter matches with the public base URL (Staging or production).
+                type: string
+              upstreamRetryCases:
+                description: UpstreamRetryCases Used only when the retry policy is configured. Specified in which cases a request to the upstream API should be retried.
+                enum:
+                - error
+                - timeout
+                - invalid_header
+                - http_500
+                - http_502
+                - http_503
+                - http_504
+                - http_403
+                - http_404
+                - http_429
+                - non_idempotent
+                - "off"
+                type: string
+            type: object
+          status:
+            description: APIcastStatus defines the observed state of APIcast
+            properties:
+              conditions:
+                description: Represents the latest available observations of a replica set's current state.
+                items:
+                  properties:
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of replica set condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              image:
+                description: The image being used in the APIcast deployment
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/apps.3scale.net_apicasts.yaml
+++ b/config/crd/bases/apps.3scale.net_apicasts.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,256 +15,256 @@ spec:
     plural: apicasts
     singular: apicast
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: APIcast is the Schema for the apicasts API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: APIcastSpec defines the desired state of APIcast
-          properties:
-            adminPortalCredentialsRef:
-              description: LocalObjectReference contains enough information to let
-                you locate the referenced object inside the same namespace.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            cacheConfigurationSeconds:
-              format: int64
-              type: integer
-            cacheMaxTime:
-              description: CacheMaxTime indicates the maximum time to be cached. If
-                cache-control header is not set, the time to be cached will be the
-                defined one.
-              type: string
-            cacheStatusCodes:
-              description: CacheStatusCodes defines the status codes for which the
-                response content will be cached.
-              type: string
-            configurationLoadMode:
-              enum:
-              - boot
-              - lazy
-              type: string
-            deploymentEnvironment:
-              type: string
-            dnsResolverAddress:
-              type: string
-            embeddedConfigurationSecretRef:
-              description: LocalObjectReference contains enough information to let
-                you locate the referenced object inside the same namespace.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            enabledServices:
-              items:
-                type: string
-              type: array
-            exposedHost:
-              properties:
-                host:
-                  type: string
-                tls:
-                  items:
-                    description: IngressTLS describes the transport layer security
-                      associated with an Ingress.
-                    properties:
-                      hosts:
-                        description: Hosts are a list of hosts included in the TLS
-                          certificate. The values in this list must match the name/s
-                          used in the tlsSecret. Defaults to the wildcard host setting
-                          for the loadbalancer controller fulfilling this Ingress,
-                          if left unspecified.
-                        items:
-                          type: string
-                        type: array
-                      secretName:
-                        description: SecretName is the name of the secret used to
-                          terminate SSL traffic on 443. Field is left optional to
-                          allow SSL routing based on SNI hostname alone. If the SNI
-                          host in a listener conflicts with the "Host" header field
-                          used by an IngressRule, the SNI host is used for termination
-                          and value of the Host header is used for routing.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - host
-              type: object
-            httpsCertificateSecretRef:
-              description: HTTPSCertificateSecretRef references secret containing
-                the X.509 certificate in the PEM format and the X.509 certificate
-                secret key.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            httpsPort:
-              description: HttpsPort controls on which port APIcast should start listening
-                for HTTPS connections. If this clashes with HTTP port it will be used
-                only for HTTPS.
-              format: int32
-              type: integer
-            httpsVerifyDepth:
-              description: HTTPSVerifyDepth defines the maximum length of the client
-                certificate chain.
-              format: int64
-              minimum: 0
-              type: integer
-            image:
-              type: string
-            loadServicesWhenNeeded:
-              description: LoadServicesWhenNeeded makes the configurations to be loaded
-                lazily. APIcast will only load the ones configured for the host specified
-                in the host header of the request.
-              type: boolean
-            logLevel:
-              enum:
-              - debug
-              - info
-              - notice
-              - warn
-              - error
-              - crit
-              - alert
-              - emerg
-              type: string
-            managementAPIScope:
-              enum:
-              - disabled
-              - status
-              - policies
-              - debug
-              type: string
-            oidcLogLevel:
-              description: OidcLogLevel allows to set the log level for the logs related
-                to OpenID Connect integration.
-              enum:
-              - debug
-              - info
-              - notice
-              - warn
-              - error
-              - crit
-              - alert
-              - emerg
-              type: string
-            openSSLPeerVerificationEnabled:
-              type: boolean
-            pathRoutingEnabled:
-              type: boolean
-            replicas:
-              format: int64
-              type: integer
-            resources:
-              description: ResourceRequirements describes the compute resource requirements.
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            responseCodesIncluded:
-              type: boolean
-            serviceAccount:
-              type: string
-            serviceConfigurationVersionOverride:
-              additionalProperties:
-                type: string
-              description: ServiceConfigurationVersionOverride contains service configuration
-                version map to prevent it from auto-updating.
-              type: object
-            servicesFilterByURL:
-              description: ServicesFilterByURL is used to filter the service configured
-                in the 3scale API Manager, the filter matches with the public base
-                URL (Staging or production).
-              type: string
-            upstreamRetryCases:
-              description: UpstreamRetryCases Used only when the retry policy is configured.
-                Specified in which cases a request to the upstream API should be retried.
-              enum:
-              - error
-              - timeout
-              - invalid_header
-              - http_500
-              - http_502
-              - http_503
-              - http_504
-              - http_403
-              - http_404
-              - http_429
-              - non_idempotent
-              - "off"
-              type: string
-          type: object
-        status:
-          description: APIcastStatus defines the observed state of APIcast
-          properties:
-            conditions:
-              description: Represents the latest available observations of a replica
-                set's current state.
-              items:
-                properties:
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of replica set condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            image:
-              description: The image being used in the APIcast deployment
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: APIcast is the Schema for the apicasts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: APIcastSpec defines the desired state of APIcast
+            properties:
+              adminPortalCredentialsRef:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              cacheConfigurationSeconds:
+                format: int64
+                type: integer
+              cacheMaxTime:
+                description: CacheMaxTime indicates the maximum time to be cached.
+                  If cache-control header is not set, the time to be cached will be
+                  the defined one.
+                type: string
+              cacheStatusCodes:
+                description: CacheStatusCodes defines the status codes for which the
+                  response content will be cached.
+                type: string
+              configurationLoadMode:
+                enum:
+                - boot
+                - lazy
+                type: string
+              deploymentEnvironment:
+                type: string
+              dnsResolverAddress:
+                type: string
+              embeddedConfigurationSecretRef:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              enabledServices:
+                items:
+                  type: string
+                type: array
+              exposedHost:
+                properties:
+                  host:
+                    type: string
+                  tls:
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
+                          items:
+                            type: string
+                          type: array
+                        secretName:
+                          description: SecretName is the name of the secret used to
+                            terminate SSL traffic on 443. Field is left optional to
+                            allow SSL routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the Host header is used for routing.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - host
+                type: object
+              httpsCertificateSecretRef:
+                description: HTTPSCertificateSecretRef references secret containing
+                  the X.509 certificate in the PEM format and the X.509 certificate
+                  secret key.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              httpsPort:
+                description: HttpsPort controls on which port APIcast should start
+                  listening for HTTPS connections. If this clashes with HTTP port
+                  it will be used only for HTTPS.
+                format: int32
+                type: integer
+              httpsVerifyDepth:
+                description: HTTPSVerifyDepth defines the maximum length of the client
+                  certificate chain.
+                format: int64
+                minimum: 0
+                type: integer
+              image:
+                type: string
+              loadServicesWhenNeeded:
+                description: LoadServicesWhenNeeded makes the configurations to be
+                  loaded lazily. APIcast will only load the ones configured for the
+                  host specified in the host header of the request.
+                type: boolean
+              logLevel:
+                enum:
+                - debug
+                - info
+                - notice
+                - warn
+                - error
+                - crit
+                - alert
+                - emerg
+                type: string
+              managementAPIScope:
+                enum:
+                - disabled
+                - status
+                - policies
+                - debug
+                type: string
+              oidcLogLevel:
+                description: OidcLogLevel allows to set the log level for the logs
+                  related to OpenID Connect integration.
+                enum:
+                - debug
+                - info
+                - notice
+                - warn
+                - error
+                - crit
+                - alert
+                - emerg
+                type: string
+              openSSLPeerVerificationEnabled:
+                type: boolean
+              pathRoutingEnabled:
+                type: boolean
+              replicas:
+                format: int64
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              responseCodesIncluded:
+                type: boolean
+              serviceAccount:
+                type: string
+              serviceConfigurationVersionOverride:
+                additionalProperties:
+                  type: string
+                description: ServiceConfigurationVersionOverride contains service
+                  configuration version map to prevent it from auto-updating.
+                type: object
+              servicesFilterByURL:
+                description: ServicesFilterByURL is used to filter the service configured
+                  in the 3scale API Manager, the filter matches with the public base
+                  URL (Staging or production).
+                type: string
+              upstreamRetryCases:
+                description: UpstreamRetryCases Used only when the retry policy is
+                  configured. Specified in which cases a request to the upstream API
+                  should be retried.
+                enum:
+                - error
+                - timeout
+                - invalid_header
+                - http_500
+                - http_502
+                - http_503
+                - http_504
+                - http_403
+                - http_404
+                - http_429
+                - non_idempotent
+                - "off"
+                type: string
+            type: object
+          status:
+            description: APIcastStatus defines the observed state of APIcast
+            properties:
+              conditions:
+                description: Represents the latest available observations of a replica
+                  set's current state.
+                items:
+                  properties:
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of replica set condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              image:
+                description: The image being used in the APIcast deployment
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -15,17 +15,20 @@ patchesStrategicMerge:
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_apicasts.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
-#
-# [APIcast CRD Configuration Source OpenAPI Validation]. This patch adds `anyOf` OpenAPI
-# validation for the configuration source of APIcas to the APIcast CRD due to at the
-# moment of writing this (2020-06-22) kubebuilder does not support `anyOf` statement
-# OpenAPI validation
-- patches/configuration_source_openapi_validation_in_apicasts.yaml
-# +kubebuilder:scaffold:crdkustomizeapicastconfigurationsourceopenapivalidationpatch
 
 # [APIcast CRD additional app label]. This patch adds the 'app' label for the APCIcast CRD
 - patches/additional_app_label_in_crd.yaml
 # +kubebuilder:scaffold:crdkustomizeadditionalapplabelincrdpatch
+
+patchesJson6902:
+# [APIcast CRD additional app label]. This patch adds the 'app' label for the APCIcast CRD
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: apicasts.apps.3scale.net
+  path: patches/configuration_source_openapi_validation_in_apicasts.yaml
+# +kubebuilder:scaffold:crdkustomizeapicastconfigurationsourceopenapivalidationpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/config/crd/patches/additional_app_label_in_crd.yaml
+++ b/config/crd/patches/additional_app_label_in_crd.yaml
@@ -1,6 +1,6 @@
 # The following patch adds the 'app' label for the APIcast CRD
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apicasts.apps.3scale.net

--- a/config/crd/patches/cainjection_in_apicasts.yaml
+++ b/config/crd/patches/cainjection_in_apicasts.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/configuration_source_openapi_validation_in_apicasts.yaml
+++ b/config/crd/patches/configuration_source_openapi_validation_in_apicasts.yaml
@@ -3,15 +3,8 @@
 # to the APIcast CRD due to at the moment
 # of writing this (2020-06-22) kubebuilder
 # does not support `anyOf` statement OpenAPI validation
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: apicasts.apps.3scale.net
-spec:
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          anyOf:
-           - required: ["adminPortalCredentialsRef"]
-           - required: ["embeddedConfigurationSecretRef"]
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/anyOf
+  value:
+    - required: ["adminPortalCredentialsRef"]
+    - required: ["embeddedConfigurationSecretRef"]

--- a/config/crd/patches/webhook_in_apicasts.yaml
+++ b/config/crd/patches/webhook_in_apicasts.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apicasts.apps.3scale.net


### PR DESCRIPTION
This PR updates the API Version of the `CustomResourceDefinition` API type from `v1beta1` to `v1` for our CRDs.
The motivation of this is that K8s is going to stop serving `v1beta1` in K8s 1.22:
```
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```

related issue: https://github.com/kubernetes/kubernetes/issues/82022

It is important to not confuse the APIVersion of the `CustomResourceDefinition` API type with the APIVersion of our CRD Types. They are different concepts. In this PR we are dealing with the former.

The following changes have been performed:
* Change controller-gen flags to generate `v1` version of CustomResourceDefinition.
* Update CRD Kustomize patch files to reference to CustomResourceDefinition `v1`
* Update the CRD kustomize patch file that deals with adding `anyOf` OpenAPI validation of the APIcast configuration source to use JSON Patch instead of JSON Strategic Merge patch. The reason for this is that now that the OpenAPI validation appears in an array of versions there's no way to perform a merge with JSON Strategic Merge patch on the array element contents as it lacks a merge key definition
* Update manifests and bundle CRDs with the new `v1` CustomResourceDefinition format. The OpenAPI validation is now specified in the versions array instead of directly in the spec.
* Update CRD manifest tests to use versioned retrieval of the CRD type schema.