### PR TITLE
fix reconcile service https port

### DIFF
--- a/controllers/apps/apicast_logic_reconciler.go
+++ b/controllers/apps/apicast_logic_reconciler.go
@@ -84,7 +84,7 @@ func (r *APIcastLogicReconciler) Reconcile() (reconcile.Result, error) {
 	// Gateway service
 	//
 	service := apicastFactory.Service()
-	err = r.ReconcileResource(&v1.Service{}, service, reconcilers.CreateOnlyMutator)
+	err = r.ReconcileResource(&v1.Service{}, service, reconcilers.ServicePortMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/reconcilers/service.go
+++ b/pkg/reconcilers/service.go
@@ -1,0 +1,29 @@
+package reconcilers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/3scale/apicast-operator/pkg/k8sutils"
+	v1 "k8s.io/api/core/v1"
+)
+
+func ServicePortMutator(existingObj, desiredObj k8sutils.KubernetesObject) (bool, error) {
+	existing, ok := existingObj.(*v1.Service)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1.Service", existingObj)
+	}
+	desired, ok := desiredObj.(*v1.Service)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1.Service", desiredObj)
+	}
+
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Ports, desired.Spec.Ports) {
+		updated = true
+		existing.Spec.Ports = desired.Spec.Ports
+	}
+
+	return updated, nil
+}


### PR DESCRIPTION
When HTTPS port is removed from the CR, the service's exposed ports were not reconciled. Added reconciliation of the ports.