### PR TITLE
metering labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,14 @@ jobs:
       - install-operator-dependencies
       - run: make test-crds
 
+  test-manifests-version:
+    docker:
+      - image: circleci/golang:1.13.7
+    steps:
+      - checkout
+      - install-operator-dependencies
+      - run: make test-manifests-version
+
   bundle-validate:
     docker:
       - image: circleci/golang:1.13.7
@@ -202,6 +210,7 @@ workflows:
       - bundle-validate
       - lint
       - test-crds
+      - test-manifests-version
       - run-e2e-test
       - install-operator:
           filters: # required since `tag-operator-image-release` job has tag filters AND requires `install-operator`. Otherwise tag build will not be triggered on new tags

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,10 @@ TEST_CRD_PKGS = $(shell go list ./... | grep 'github.com/3scale/apicast-operator
 test-crds: generate fmt vet manifests
 	go test -v $(TEST_CRD_PKGS)
 
+## test-manifests-version: Run manifest version checks
+test-manifests-version:
+	cd $(PROJECT_PATH)/test/manifests-version && go test -v
+
 # Run e2e tests
 
 TEST_E2E_PKGS = $(shell go list ./... | grep -E 'github.com/3scale/apicast-operator/controllers')

--- a/bundle/manifests/apicast-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/apicast-operator.clusterserviceversion.yaml
@@ -90,7 +90,14 @@ spec:
             metadata:
               labels:
                 app: apicast
+                com.company: Red_Hat
                 control-plane: controller-manager
+                rht.comp: 3scale_apicast
+                rht.comp_ver: master
+                rht.prod_name: Red_Hat_Integration
+                rht.prod_ver: master
+                rht.subcomp: apicast_operator
+                rht.subcomp_t: infrastructure
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,13 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        com.company: Red_Hat
+        rht.prod_name: Red_Hat_Integration
+        rht.prod_ver: master
+        rht.comp: 3scale_apicast
+        rht.comp_ver: master
+        rht.subcomp: apicast_operator
+        rht.subcomp_t: infrastructure
     spec:
       serviceAccountName: apicast-operator
       containers:

--- a/controllers/apps/apicast_logic_reconciler.go
+++ b/controllers/apps/apicast_logic_reconciler.go
@@ -83,6 +83,7 @@ func (r *APIcastLogicReconciler) Reconcile(ctx context.Context) (reconcile.Resul
 		reconcilers.DeploymentVolumesMutator,
 		reconcilers.DeploymentVolumeMountsMutator,
 		reconcilers.DeploymentPortsMutator,
+		reconcilers.DeploymentTemplateLabelsMutator,
 	)
 	deployment := apicastFactory.Deployment()
 	err = r.ReconcileResource(ctx, &appsv1.Deployment{}, deployment, deploymentMutator)

--- a/pkg/apicast/apicast.go
+++ b/pkg/apicast/apicast.go
@@ -345,18 +345,18 @@ func (a *APIcast) Deployment() *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.options.DeploymentName,
 			Namespace: a.options.Namespace,
-			Labels:    a.commonLabels(),
+			Labels:    a.options.CommonLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: a.deploymentLabelSelector(),
+				MatchLabels: a.options.PodTemplateLabels,
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      a.deploymentLabelSelector(),
+					Labels:      a.options.PodTemplateLabels,
 					Annotations: a.podAnnotations(),
 				},
 				Spec: v1.PodSpec{
@@ -387,19 +387,6 @@ func (a *APIcast) Deployment() *appsv1.Deployment {
 	return deployment
 }
 
-func (a *APIcast) deploymentLabelSelector() map[string]string {
-	return map[string]string{
-		"deployment": a.options.DeploymentName,
-	}
-}
-
-func (a *APIcast) commonLabels() map[string]string {
-	return map[string]string{
-		"app":                  a.options.AppLabel,
-		"threescale_component": "apicast",
-	}
-}
-
 func (a *APIcast) podAnnotations() map[string]string {
 	annotations := map[string]string{
 		"prometheus.io/scrape": "true",
@@ -422,11 +409,11 @@ func (a *APIcast) Service() *v1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.options.ServiceName,
 			Namespace: a.options.Namespace,
-			Labels:    a.commonLabels(),
+			Labels:    a.options.CommonLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports:    a.servicePorts(),
-			Selector: a.deploymentLabelSelector(),
+			Selector: a.options.PodTemplateLabels,
 		},
 	}
 
@@ -501,7 +488,7 @@ func (a *APIcast) Ingress() *networkingv1.Ingress {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.options.DeploymentName,
 			Namespace: a.options.Namespace,
-			Labels:    a.commonLabels(),
+			Labels:    a.options.CommonLabels,
 		},
 		Spec: networkingv1.IngressSpec{
 			TLS: a.options.ExposedHost.TLS,

--- a/pkg/apicast/apicast_options.go
+++ b/pkg/apicast/apicast_options.go
@@ -31,7 +31,6 @@ type APIcastOptions struct {
 	Owner                        *metav1.OwnerReference `validate:"required"`
 	ServiceName                  string                 `validate:"required"`
 	Replicas                     int32
-	AppLabel                     string                  `validate:"required"`
 	AdditionalAnnotations        map[string]string       `validate:"required"`
 	ServiceAccountName           string                  `validate:"required"`
 	Image                        string                  `validate:"required"`
@@ -70,6 +69,9 @@ type APIcastOptions struct {
 	HTTPProxy                           *string
 	HTTPSProxy                          *string
 	NoProxy                             *string
+
+	CommonLabels      map[string]string `validate:"required"`
+	PodTemplateLabels map[string]string `validate:"required"`
 }
 
 func NewAPIcastOptions() *APIcastOptions {

--- a/pkg/helper/labels.go
+++ b/pkg/helper/labels.go
@@ -1,0 +1,25 @@
+package helper
+
+import (
+	"github.com/3scale/apicast-operator/version"
+)
+
+type ComponentType string
+
+const (
+	ApplicationType    ComponentType = "application"
+	InfrastructureType ComponentType = "infrastructure"
+)
+
+func MeteringLabels(componentType ComponentType) map[string]string {
+	return map[string]string{
+		"com.company":   "Red_Hat",
+		"rht.prod_name": "Red_Hat_Integration",
+		// It should be updated on release branch
+		"rht.prod_ver":  "master",
+		"rht.comp":      "3scale_apicast",
+		"rht.comp_ver":  version.ThreescaleRelease,
+		"rht.subcomp":   "apicast",
+		"rht.subcomp_t": string(componentType),
+	}
+}

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -142,3 +142,11 @@ func DeploymentPortsMutator(desired, existing *appsv1.Deployment) bool {
 
 	return update
 }
+
+func DeploymentTemplateLabelsMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	k8sutils.MergeMapStringString(&update, &existing.Spec.Template.Labels, desired.Spec.Template.Labels)
+
+	return update
+}

--- a/test/manifests-version/deployment_version_test.go
+++ b/test/manifests-version/deployment_version_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/3scale/apicast-operator/version"
+
+	appsv1 "k8s.io/api/apps/v1"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func TestDeploymentVersions(t *testing.T) {
+	root := "../../config/manager/"
+	path := path.Join(root, "manager.yaml")
+	yamlBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bytesReader := ioutil.NopCloser(bytes.NewReader(yamlBytes))
+	yamlDocumentDecoder := utilyaml.NewDocumentDecoder(bytesReader)
+
+	// Read and discard Namespace object from the yaml file
+	res := make([]byte, len(yamlBytes))
+	_, err = yamlDocumentDecoder.Read(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the Deployment object from the yaml file
+	n, err := yamlDocumentDecoder.Read(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy the Deployment object bytes length
+	deploymentBytes := make([]byte, n)
+	copy(deploymentBytes, res[:n])
+
+	// Decode the Deployment object
+	deployment := appsv1.Deployment{}
+	fd := bytes.NewReader(deploymentBytes)
+	yamlDecoder := utilyaml.NewYAMLOrJSONDecoder(fd, fd.Len())
+	err = yamlDecoder.Decode(&deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if deployment.Kind != "Deployment" {
+		t.Errorf("Parsed object is not a Deployment object")
+	}
+
+	if deployment.Spec.Template.Labels["rht.comp_ver"] != version.ThreescaleRelease {
+		t.Errorf("rht.comp_ver differ: expected: %s; found: %s", version.ThreescaleRelease, deployment.Spec.Template.Labels["rht.comp_ver"])
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
 var (
-	Version = "0.6.0"
+	Version           = "0.6.0"
+	ThreescaleRelease = "master"
 )


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-7751

* Added metering labels to operator deployment
* Added metering labels to apicast pod (via deployment pod template labels)
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    com.company: Red_Hat
    deployment: apicast-apicast1
    pod-template-hash: 55f85485ff
    rht.comp: 3scale_apicast
    rht.comp_ver: master
    rht.prod_name: Red_Hat_Integration
    rht.prod_ver: master
    rht.subcomp: apicast
    rht.subcomp_t: application
```

* Added `test-manifest-version` circleci check to verify operator labels match operator version
* Added `version.ThreescaleRelease` attribute to be used in the metering labels
* Added reconcilliation of deployment pod template labels. Merge type (missing will be added, existing updated)
* No need to add upgrade, as previous releases did not have metering labels. However, it will be needed for future releases as the release number is included in the metering labels