### PR TITLE
Rename tracingConfigRef to tracingConfigSecretRef

### DIFF
--- a/apis/apps/v1alpha1/apicast_types.go
+++ b/apis/apps/v1alpha1/apicast_types.go
@@ -212,11 +212,11 @@ type OpenTracingSpec struct {
 	// the only supported tracer is `jaeger`. If not set, `jaeger` will be used.
 	// +optional
 	TracingLibrary *string `json:"tracingLibrary,omitempty"`
-	// TracingConfig contains a secret reference the OpenTracing configuration.
+	// TracingConfigSecretRef contains a Secret reference the OpenTracing configuration.
 	// Each supported tracing library provides a default configuration file
 	// that is used if TracingConfig is not specified.
 	// +optional
-	TracingConfigSecretRef *v1.LocalObjectReference `json:"tracingConfigRef,omitempty"`
+	TracingConfigSecretRef *v1.LocalObjectReference `json:"tracingConfigSecretRef,omitempty"`
 }
 
 // APIcastStatus defines the observed state of APIcast.

--- a/bundle/manifests/apps.3scale.net_apicasts.yaml
+++ b/bundle/manifests/apps.3scale.net_apicasts.yaml
@@ -207,8 +207,8 @@ spec:
                   enabled:
                     description: Enabled controls whether OpenTracing integration with APIcast is enabled. By default it is not enabled.
                     type: boolean
-                  tracingConfigRef:
-                    description: TracingConfig contains a secret reference the OpenTracing configuration. Each supported tracing library provides a default configuration file that is used if TracingConfig is not specified.
+                  tracingConfigSecretRef:
+                    description: TracingConfigSecretRef contains a Secret reference the OpenTracing configuration. Each supported tracing library provides a default configuration file that is used if TracingConfig is not specified.
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'

--- a/config/crd/bases/apps.3scale.net_apicasts.yaml
+++ b/config/crd/bases/apps.3scale.net_apicasts.yaml
@@ -260,10 +260,11 @@ spec:
                     description: Enabled controls whether OpenTracing integration
                       with APIcast is enabled. By default it is not enabled.
                     type: boolean
-                  tracingConfigRef:
-                    description: TracingConfig contains a secret reference the OpenTracing
-                      configuration. Each supported tracing library provides a default
-                      configuration file that is used if TracingConfig is not specified.
+                  tracingConfigSecretRef:
+                    description: TracingConfigSecretRef contains a Secret reference
+                      the OpenTracing configuration. Each supported tracing library
+                      provides a default configuration file that is used if TracingConfig
+                      is not specified.
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/doc/apicast-crd-reference.md
+++ b/doc/apicast-crd-reference.md
@@ -127,7 +127,7 @@ Some examples are available [here](/doc/adding-custom-environments.md)
 | --- | --- | --- | --- | --- |
 | `enabled` | bool | No | `false` | Controls whether OpenTracing integration with APIcast is enabled. By default it is not enabled |
 | `tracingLibrary` | string | No | `jaeger` | Controls which OpenTracing library is loaded. At the moment the supported values are: `jaeger`. If not set, `jaeger` will be used |
-| `tracingConfigRef` | LocalObjectReference | No | tracing library-specific default | Secret reference with the tracing library-specific configuration. Each supported tracing library provides a default configuration file which is used if `tracingConfigRef` is not specified. See [TracingConfigSecret](#TracingConfigSecret) for more information. |
+| `tracingConfigSecretRef` | LocalObjectReference | No | tracing library-specific default | Secret reference with the tracing library-specific configuration. Each supported tracing library provides a default configuration file which is used if `tracingConfigSecretRef` is not specified. See [TracingConfigSecret](#TracingConfigSecret) for more information. |
 
 ### TracingConfigSecret
 
@@ -141,5 +141,5 @@ However, apicast has the environment already loaded and it does not change the b
 
 If the custom environment content needs to be changed, there are two options:
 
-* [**recommended way**] Create another secret with a different name and update the APIcast custom resource field `spec.openTracing.tracingConfigRef.name`. The operator will trigger a rolling update loading the new custom environment content.
+* [**recommended way**] Create another secret with a different name and update the APIcast custom resource field `spec.openTracing.tracingConfigSecretRef.name`. The operator will trigger a rolling update loading the new custom environment content.
 * Update the existing secret content and redeploy apicast turning `spec.replicas` to 0 and then back to the previous value.


### PR DESCRIPTION
Rename `.spec.openTracing.tracingConfigRef` to `.spec.openTracing.tracingConfigSecretRef` to better indicate that the config to be provided is a K8s secret