### PR TITLE
bundle common label: app=apicast

### DIFF
--- a/bundle/manifests/apicast-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/apicast-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app: apicast
     control-plane: controller-manager
   name: apicast-operator-controller-manager-metrics-service
 spec:
@@ -11,6 +12,7 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app: apicast
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/apicast-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/apicast-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app: apicast
   name: apicast-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/apicast-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/apicast-operator.clusterserviceversion.yaml
@@ -98,11 +98,13 @@ spec:
           replicas: 1
           selector:
             matchLabels:
+              app: apicast
               control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               labels:
+                app: apicast
                 control-plane: controller-manager
             spec:
               containers:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,10 +16,6 @@ patchesStrategicMerge:
 #- patches/cainjection_in_apicasts.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-# [APIcast CRD additional app label]. This patch adds the 'app' label for the APCIcast CRD
-- patches/additional_app_label_in_crd.yaml
-# +kubebuilder:scaffold:crdkustomizeadditionalapplabelincrdpatch
-
 patchesJson6902:
 # [APIcast CRD additional app label]. This patch adds the 'app' label for the APCIcast CRD
 - target:

--- a/config/crd/patches/additional_app_label_in_crd.yaml
+++ b/config/crd/patches/additional_app_label_in_crd.yaml
@@ -1,8 +1,0 @@
-# The following patch adds the 'app' label for the APIcast CRD
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: apicasts.apps.3scale.net
-  labels:
-    app: apicast

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: apicast-operator-system
 namePrefix: apicast-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app: apicast
 
 bases:
 - ../crd


### PR DESCRIPTION
New label added to all operator bundle resources: CSV, CRDs, services, servicemonitor, deployment, roles, rolebindings, servicemonitors
```
app: apicast
```