### PR TITLE
change operator deployment name

### DIFF
--- a/bundle/manifests/apicast-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/apicast-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ spec:
   install:
     spec:
       deployments:
-      - name: apicast-operator-controller-manager
+      - name: apicast-operator-controller-manager-v2
         spec:
           replicas: 1
           selector:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
   labels:
     control-plane: controller-manager


### PR DESCRIPTION
Deployment label selector field is inmutable. Apicast operator specific labels were added in #164, effectively changing the existing labels from 2.11.0 to 2.11.1. On upgrade scenarios, OLM will try to patch/update a field that is inmutable. Hence, it fails.

It has already been reported here: https://github.com/operator-framework/operator-lifecycle-manager/issues/952

The fix is about changing the name of the deployment. On upgrade scenarios, OLM will detect the deployment name change and will delete the previous deployment and CREATE (not update or patch) the new deployment with the new labels in the selector successfully.