### PR TITLE
cluster scope mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ bundle-custom-build: | bundle-custom-updates bundle-build bundle-restore
 
 .PHONY: bundle-run
 bundle-run: $(OPERATOR_SDK)
-	$(OPERATOR_SDK) run bundle --namespace $(NAMESPACE) $(BUNDLE_IMG)
+	$(OPERATOR_SDK) run bundle --namespace openshift-marketplace $(BUNDLE_IMG)
 
 GOLANGCI-LINT=$(PROJECT_PATH)/bin/golangci-lint
 $(GOLANGCI-LINT):

--- a/bundle/manifests/apicast-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/apicast-operator.clusterserviceversion.yaml
@@ -124,10 +124,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 300Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 300Mi
               serviceAccountName: apicast-operator
               terminationGracePeriodSeconds: 10
       permissions:
@@ -273,7 +273,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - 3scale

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,10 +40,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 300Mi
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/config/manifests/bases/apicast-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/apicast-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - 3scale

--- a/doc/development.md
+++ b/doc/development.md
@@ -107,6 +107,12 @@ make bundle-image-push BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator-
 make bundle-run BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator-bundles:myversiontag
 ```
 
+**Note**: The _catalogsource_ will be installed in the `openshift-marketplace` namespace
+[issue](https://bugzilla.redhat.com/show_bug.cgi?id=1779080). By default, cluster scoped
+subscription will be created in the namespace `openshift-marketplace`.
+Feel free to delete the operator (from the UI **OperatorHub -> Installed Operators**)
+and install it namespace or cluster scoped.
+
 It will take a few minutes for the operator to become visible under
 the _OperatorHub_ section of the OpenShift console _Catalog_. It can be
 easily found by filtering the provider type to _Custom_.


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/THREESCALE-7960

### what

Change operator to also be cluster scoped using OLM

### Verification steps

Build and upload custom operator image

```
export DOCKER_REGISTRY=quay.io
export DOCKER_ORG=<youre quay.io org>
make docker-build-only IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:cluster-mode
make operator-image-push IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:cluster-mode
```

Build and upload custom operator bundle image. 

```
make bundle-custom-build IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:cluster-mode BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:cluster-mode-bundle
make bundle-image-push BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:cluster-mode-bundle
```

Deploy the operator in your currently configured and active cluster in $HOME/.kube/config

```
make bundle-run BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:cluster-mode-bundle
```

Once installed you should see it installed as cluster scoped i.e. All namespaces

![Screenshot 2022-03-22 at 12-02-48 Installed Operators · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/881529/159467814-9ce2be86-eaaa-4058-bcf1-df44b072e7ae.png)

