### PR TITLE
fix docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,8 +216,6 @@ workflows:
           filters: # required since `tag-operator-image-release` job has tag filters AND requires `install-operator`. Otherwise tag build will not be triggered on new tags
             tags:
               only: /^v.*/
-            branches:
-              only: master
       - tag-operator-image-master:
           context: org-global
           requires:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/doc/development.md
+++ b/doc/development.md
@@ -23,10 +23,10 @@
 * [operator-sdk] version v1.2.0
 * [docker] version 17.03+
 * [git][git_tool]
-* [go] version 1.13+
-* [kubernetes] version v1.19.0+
-* [kubectl] version v1.19.0+
-* Access to a Kubernetes v1.19.0+ cluster.
+* [go] version 1.17+
+* [kubernetes] version v1.22.1+
+* [kubectl] version v1.22.0+
+* Access to a Kubernetes v1.21.0+ cluster.
 * A user with administrative privileges in the Kubernetes cluster.
 * Make sure that the `DOCKER_ORG` and `DOCKER_REGISTRY` environment variables are set to the same value as
   your username on the container registry, and the container registry you are using.


### PR DESCRIPTION
### What

The docker image build was broken and the CI test did not detected it due to a misconfiguration. Both issues fixed.