### PR TITLE
THREESCALE-8749: Ability to set APICAST_SERVICE_CACHE_SIZE

### DIFF
--- a/apis/apps/v1alpha1/apicast_types.go
+++ b/apis/apps/v1alpha1/apicast_types.go
@@ -142,6 +142,9 @@ type APIcastSpec struct {
 	// CacheStatusCodes defines the status codes for which the response content will be cached.
 	// +optional
 	CacheStatusCodes *string `json:"cacheStatusCodes,omitempty"` // APICAST_CACHE_STATUS_CODES
+	// ServiceCacheSize specifies the number of services that APICast can store in the internal cache
+	// +optional
+	ServiceCacheSize *int32 `json:"serviceCacheSize,omitempty"`
 	// OidcLogLevel allows to set the log level for the logs related to OpenID Connect integration.
 	// +kubebuilder:validation:Enum=debug;info;notice;warn;error;crit;alert;emerg
 	// +optional

--- a/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -226,6 +226,11 @@ func (in *APIcastSpec) DeepCopyInto(out *APIcastSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceCacheSize != nil {
+		in, out := &in.ServiceCacheSize, &out.ServiceCacheSize
+		*out = new(int32)
+		**out = **in
+	}
 	if in.OidcLogLevel != nil {
 		in, out := &in.OidcLogLevel, &out.OidcLogLevel
 		*out = new(string)

--- a/bundle/manifests/apps.3scale.net_apicasts.yaml
+++ b/bundle/manifests/apps.3scale.net_apicasts.yaml
@@ -271,6 +271,10 @@ spec:
               serviceAccount:
                 description: Kubernetes Service Account name to be used for the APIcast Deployment. The Service Account must exist beforehand.
                 type: string
+              serviceCacheSize:
+                description: ServiceCacheSize specifies the number of services that APICast can store in the internal cache
+                format: int32
+                type: integer
               serviceConfigurationVersionOverride:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/apps.3scale.net_apicasts.yaml
+++ b/config/crd/bases/apps.3scale.net_apicasts.yaml
@@ -345,6 +345,11 @@ spec:
                 description: Kubernetes Service Account name to be used for the APIcast
                   Deployment. The Service Account must exist beforehand.
                 type: string
+              serviceCacheSize:
+                description: ServiceCacheSize specifies the number of services that
+                  APICast can store in the internal cache
+                format: int32
+                type: integer
               serviceConfigurationVersionOverride:
                 additionalProperties:
                   type: string

--- a/doc/apicast-crd-reference.md
+++ b/doc/apicast-crd-reference.md
@@ -46,6 +46,7 @@
 | `httpProxy` | string | No | N/A | Specifies a HTTP(S) Proxy to be used for connecting to HTTP services. Authentication is not supported. Format is: `<scheme>://<host>:<port>` (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#http_proxy-http_proxy)) |
 | `httpsProxy` | string | No | N/A | Specifies a HTTP(S) Proxy to be used for connecting to HTTPS services. Authentication is not supported. Format is: `<scheme>://<host>:<port>` (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#https_proxy-https_proxy)) |
 | `noProxy` | string | No | N/A | Specifies a comma-separated list of hostnames and domain names for which the requests should not be proxied. Setting to a single `*` character, which matches all hosts, effectively disables the proxy (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#no_proxy-no_proxy)) |
+| `serviceCacheSize` | int | No | N/A | Specifies the number of services that APICast can store in the internal cache (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_service_cache_size)) |
 
 #### APIcastStatus
 

--- a/pkg/apicast/apicast.go
+++ b/pkg/apicast/apicast.go
@@ -256,6 +256,10 @@ func (a *APIcast) deploymentEnv() []v1.EnvVar {
 		env = append(env, k8sutils.EnvVarFromValue("APICAST_CACHE_STATUS_CODES", *a.options.CacheStatusCodes))
 	}
 
+	if a.options.ServiceCacheSize != nil {
+		env = append(env, k8sutils.EnvVarFromValue("APICAST_SERVICE_CACHE_SIZE", fmt.Sprintf("%d", *a.options.ServiceCacheSize)))
+	}
+
 	if a.options.OidcLogLevel != nil {
 		env = append(env, k8sutils.EnvVarFromValue("APICAST_OIDC_LOG_LEVEL", *a.options.OidcLogLevel))
 	}

--- a/pkg/apicast/apicast_option_provider.go
+++ b/pkg/apicast/apicast_option_provider.go
@@ -101,6 +101,7 @@ func (a *APIcastOptionsProvider) GetApicastOptions(ctx context.Context) (*APIcas
 	a.APIcastOptions.UpstreamRetryCases = a.APIcastCR.Spec.UpstreamRetryCases
 	a.APIcastOptions.CacheMaxTime = a.APIcastCR.Spec.CacheMaxTime
 	a.APIcastOptions.CacheStatusCodes = a.APIcastCR.Spec.CacheStatusCodes
+	a.APIcastOptions.ServiceCacheSize = a.APIcastCR.Spec.ServiceCacheSize
 	a.APIcastOptions.OidcLogLevel = a.APIcastCR.Spec.OidcLogLevel
 	a.APIcastOptions.LoadServicesWhenNeeded = a.APIcastCR.Spec.LoadServicesWhenNeeded
 	a.APIcastOptions.ServicesFilterByURL = a.APIcastCR.Spec.ServicesFilterByURL

--- a/pkg/apicast/apicast_options.go
+++ b/pkg/apicast/apicast_options.go
@@ -50,6 +50,7 @@ type APIcastOptions struct {
 	ManagementAPIScope                  *string
 	OpenSSLPeerVerificationEnabled      *bool
 	UpstreamRetryCases                  *string
+	ServiceCacheSize                    *int32
 	CacheMaxTime                        *string
 	CacheStatusCodes                    *string
 	OidcLogLevel                        *string


### PR DESCRIPTION
## Description

Add optional field in the Apicast resource that sets the `APICAST_SERVICE_CACHE_SIZE` environment variable in the Apicast container

## Verification steps

On a cluster, run the operator and create an APICast with the new field set. Check that once reconciled the `Deployment` includes the environment variable with the value from the new fields:

1. Apply the manifests
    ```sh
    make install
    ``` 
2. Run the operator
    ```sh
    make run
    ```
3. Create an APICast that includes the following in the spec:
    ```yaml
    spec:
      // ...   
      serviceCacheSize: 42
    ```
4. Check the Deployment for APICast
    ```sh
    oc get deployment/apicast-example-apicast -o yaml
    ```
5. Verify that they include the environment variable
    ```yaml
    # ...
    - name: APICAST_SERVICE_CACHE_SIZE
       value: '42'
    # ...
    ```