### PR TITLE
circleci: update ubuntu base image to ubuntu-2404:current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   tag-operator-image-master:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -89,7 +89,7 @@ jobs:
 
   tag-operator-image-release:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -118,7 +118,7 @@ jobs:
             make test-unit
   run-integration-test:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - go/install:


### PR DESCRIPTION
### What

circleci machine image `ubuntu-2004:202201-02` is being deprecated https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

### Verification steps

Create tag following `/^v.*/` regexp, and circleci should push image to quay.io. 

I added custom (temporary) tag `v0.9.1-this-is-a-test` and [circleci job](https://app.circleci.com/pipelines/github/3scale/apicast-operator/904/workflows/932195b9-fb24-4681-97e6-f394fc4dafef/jobs/4340) succeeded. 