### PR TITLE
THREESCALE-11385 Community release of APIcast Operator v0.8.0 (2.14.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,20 +9,16 @@ PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 all: manager
 
 # Current Operator version
-VERSION ?= 0.0.1
+VERSION ?= 0.8.0
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
+BUNDLE_CHANNELS := --channels="alpha,stable"
+BUNDLE_DEFAULT_CHANNEL := --default-channel=stable
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/3scale/apicast-operator:master
+IMG ?= quay.io/3scale/apicast-operator:v0.8.0
 
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,12 +4,14 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=apicast-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.2.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/apicast-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/apicast-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/3scale/apicast-operator:master
+    containerImage: quay.io/3scale/apicast-operator:v0.8.0
     createdAt: "2019-10-27T22:40:00Z"
     description: APIcast is an API gateway built on top of NGINX. It is part of the Red Hat 3scale API Management Platform
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -32,7 +32,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: apicast-operator.v0.0.1
+  name: apicast-operator.v0.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -55,10 +55,10 @@ spec:
 
     ### Upgrading your installation
     The APIcast Operator understands how to run and upgrade between a set of APIcast versions.
-    See [the upgrade guide](https://github.com/3scale/apicast-operator) for more information.
+    See [the upgrade guide](https://github.com/3scale/apicast-operator/blob/v0.8.0/doc/operator-user-guide.md#upgrading-APIcast) for more information.
 
     ### Documentation
-    Documentation can be found on our [website](https://github.com/3scale/apicast-operator).
+    Documentation can be found on our [website](https://github.com/3scale/apicast-operator/tree/v0.8.0).
 
     ### Getting help
     If you encounter any issues while using operator, you can create an issue on our [website](https://github.com/3scale/apicast-operator) for bugs, enhancements, or other requests.
@@ -75,7 +75,7 @@ spec:
 
     ### License
     APIcast Operator is licensed under the [Apache 2.0 license](https://github.com/3scale/apicast-operator/blob/master/LICENSE)
-  displayName: APIcast (development latest)
+  displayName: APIcast
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTAwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDEwMCA1MCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggNTQuMSAoNzY0OTApIC0gaHR0cHM6Ly9za2V0Y2hhcHAuY29tIC0tPgogICAgPHRpdGxlPkdyb3VwIDI8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iR3JvdXAtMiI+CiAgICAgICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUiIGZpbGw9IiNGRkZGRkYiIHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAiIGhlaWdodD0iNTAiPjwvcmVjdD4KICAgICAgICAgICAgPGcgaWQ9Ikdyb3VwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxOS45NDY4MDksIDAuMDAwMDAwKSIgZmlsbD0iI0ZGNzMxNCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgICAgIDxnIGlkPSJsb2dvLW1hcmsiPgogICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLDkuMDUyNjMxNjEgQzAsNCA0LjIyMzY5MTg1LDAgOS4zMTM3ODE4MywwIEMxNC41MTIxNzE1LDAgMTguNjI3NTYzOCw0LjEwNTI2MzA2IDE4LjYyNzU2MzgsOS4wNTI2MzE2MSBDMTguNjI3NTYzOCwxNC4xMDUyNjMxIDE0LjQwMzg3MiwxOC4xMDUyNjMxIDkuMzEzNzgxODMsMTguMTA1MjYzMSBDNC4yMjM2OTE4NSwxOC4xMDUyNjMxIDAsMTQuMTA1MjYzMSAwLDkuMDUyNjMxNjEgTTQ4LjYyNjYwNTQsMTEuODk0NzM2OSBDNDguNjI2NjA1NCw4Ljg0MjEwNTMyIDUxLjIyNTgwMDEsNi4zMTU3ODkzNSA1NC4zNjY0OTQyLDYuMzE1Nzg5MzUgQzU3LjUwNzE4OCw2LjMxNTc4OTM1IDYwLjEwNjM4Myw4Ljg0MjEwNTMyIDYwLjEwNjM4MywxMS44OTQ3MzY5IEM2MC4xMDYzODMsMTQuOTQ3MzY4NCA1Ny41MDcxODgsMTcuNDczNjg0NCA1NC4zNjY0OTQyLDE3LjQ3MzY4NDQgQzUxLjExNzUwMDQsMTcuNDczNjg0NCA0OC42MjY2MDU0LDE1LjA1MjYzMTYgNDguNjI2NjA1NCwxMS44OTQ3MzY5IE0zMi45MjMxMzYsMzguMTA1MjYzMSBDMzIuOTIzMTM2LDMxLjU3ODk0NzMgMzguNDQ2NDI1MiwyNi4yMTA1MjYzIDQ1LjE2MTAxMiwyNi4yMTA1MjYzIEM1MS44NzU1OTg5LDI2LjIxMDUyNjMgNTcuMzk4ODg4MiwzMS41Nzg5NDczIDU3LjM5ODg4ODIsMzguMTA1MjYzMSBDNTcuMzk4ODg4Miw0NC42MzE1NzkgNTEuODc1NTk4OSw1MCA0NS4xNjEwMTIsNTAgQzM4LjQ0NjQyNTIsNTAgMzIuOTIzMTM2LDQ0LjczNjg0MTkgMzIuOTIzMTM2LDM4LjEwNTI2MzEiIGlkPSJTaGFwZSI+PC9wYXRoPgogICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=
     mediatype: image/svg+xml
@@ -115,8 +115,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_APICAST
-                  value: quay.io/3scale/apicast:latest
-                image: quay.io/3scale/apicast-operator:master
+                  value: quay.io/3scale/apicast:3scale-2.14.1-GA
+                image: quay.io/3scale/apicast-operator:v0.8.0
                 name: manager
                 ports:
                 - containerPort: 8080
@@ -288,7 +288,7 @@ spec:
   - name: GitHub
     url: https://github.com/3scale/apicast-operator
   - name: Documentation
-    url: https://github.com/3scale/apicast-operator/tree/master
+    url: https://github.com/3scale/apicast-operator/tree/v0.8.0
   maintainers:
   - email: eastizle+apicastoperator@redhat.com
     name: Eguzki Astiz
@@ -296,4 +296,5 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Red Hat
-  version: 0.0.1
+  replaces: apicast-operator.v0.7.1
+  version: 0.8.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,5 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/apicast-operator
-  newTag: master
+  newTag: v0.8.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,5 +50,5 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_APICAST
-          value: "quay.io/3scale/apicast:latest"
+          value: "quay.io/3scale/apicast:3scale-2.14.1-GA"
       terminationGracePeriodSeconds: 10

--- a/config/manifests/bases/apicast-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/apicast-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/3scale/apicast-operator:master
+    containerImage: quay.io/3scale/apicast-operator:v0.8.0
     createdAt: "2019-10-27T22:40:00Z"
     description: APIcast is an API gateway built on top of NGINX. It is part of the Red Hat 3scale API Management Platform
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -41,10 +41,10 @@ spec:
 
     ### Upgrading your installation
     The APIcast Operator understands how to run and upgrade between a set of APIcast versions.
-    See [the upgrade guide](https://github.com/3scale/apicast-operator) for more information.
+    See [the upgrade guide](https://github.com/3scale/apicast-operator/blob/v0.8.0/doc/operator-user-guide.md#upgrading-APIcast) for more information.
 
     ### Documentation
-    Documentation can be found on our [website](https://github.com/3scale/apicast-operator).
+    Documentation can be found on our [website](https://github.com/3scale/apicast-operator/tree/v0.8.0).
 
     ### Getting help
     If you encounter any issues while using operator, you can create an issue on our [website](https://github.com/3scale/apicast-operator) for bugs, enhancements, or other requests.
@@ -61,7 +61,7 @@ spec:
 
     ### License
     APIcast Operator is licensed under the [Apache 2.0 license](https://github.com/3scale/apicast-operator/blob/master/LICENSE)
-  displayName: APIcast (development latest)
+  displayName: APIcast
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTAwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDEwMCA1MCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggNTQuMSAoNzY0OTApIC0gaHR0cHM6Ly9za2V0Y2hhcHAuY29tIC0tPgogICAgPHRpdGxlPkdyb3VwIDI8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iR3JvdXAtMiI+CiAgICAgICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUiIGZpbGw9IiNGRkZGRkYiIHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAiIGhlaWdodD0iNTAiPjwvcmVjdD4KICAgICAgICAgICAgPGcgaWQ9Ikdyb3VwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxOS45NDY4MDksIDAuMDAwMDAwKSIgZmlsbD0iI0ZGNzMxNCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgICAgIDxnIGlkPSJsb2dvLW1hcmsiPgogICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLDkuMDUyNjMxNjEgQzAsNCA0LjIyMzY5MTg1LDAgOS4zMTM3ODE4MywwIEMxNC41MTIxNzE1LDAgMTguNjI3NTYzOCw0LjEwNTI2MzA2IDE4LjYyNzU2MzgsOS4wNTI2MzE2MSBDMTguNjI3NTYzOCwxNC4xMDUyNjMxIDE0LjQwMzg3MiwxOC4xMDUyNjMxIDkuMzEzNzgxODMsMTguMTA1MjYzMSBDNC4yMjM2OTE4NSwxOC4xMDUyNjMxIDAsMTQuMTA1MjYzMSAwLDkuMDUyNjMxNjEgTTQ4LjYyNjYwNTQsMTEuODk0NzM2OSBDNDguNjI2NjA1NCw4Ljg0MjEwNTMyIDUxLjIyNTgwMDEsNi4zMTU3ODkzNSA1NC4zNjY0OTQyLDYuMzE1Nzg5MzUgQzU3LjUwNzE4OCw2LjMxNTc4OTM1IDYwLjEwNjM4Myw4Ljg0MjEwNTMyIDYwLjEwNjM4MywxMS44OTQ3MzY5IEM2MC4xMDYzODMsMTQuOTQ3MzY4NCA1Ny41MDcxODgsMTcuNDczNjg0NCA1NC4zNjY0OTQyLDE3LjQ3MzY4NDQgQzUxLjExNzUwMDQsMTcuNDczNjg0NCA0OC42MjY2MDU0LDE1LjA1MjYzMTYgNDguNjI2NjA1NCwxMS44OTQ3MzY5IE0zMi45MjMxMzYsMzguMTA1MjYzMSBDMzIuOTIzMTM2LDMxLjU3ODk0NzMgMzguNDQ2NDI1MiwyNi4yMTA1MjYzIDQ1LjE2MTAxMiwyNi4yMTA1MjYzIEM1MS44NzU1OTg5LDI2LjIxMDUyNjMgNTcuMzk4ODg4MiwzMS41Nzg5NDczIDU3LjM5ODg4ODIsMzguMTA1MjYzMSBDNTcuMzk4ODg4Miw0NC42MzE1NzkgNTEuODc1NTk4OSw1MCA0NS4xNjEwMTIsNTAgQzM4LjQ0NjQyNTIsNTAgMzIuOTIzMTM2LDQ0LjczNjg0MTkgMzIuOTIzMTM2LDM4LjEwNTI2MzEiIGlkPSJTaGFwZSI+PC9wYXRoPgogICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=
     mediatype: image/svg+xml
@@ -91,7 +91,7 @@ spec:
   - name: GitHub
     url: https://github.com/3scale/apicast-operator
   - name: Documentation
-    url: https://github.com/3scale/apicast-operator/tree/master
+    url: https://github.com/3scale/apicast-operator/tree/v0.8.0
   maintainers:
   - email: eastizle+apicastoperator@redhat.com
     name: Eguzki Astiz
@@ -99,4 +99,5 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Red Hat
+  replaces: apicast-operator.v0.7.1
   version: 0.0.0

--- a/doc/community-release-build.md
+++ b/doc/community-release-build.md
@@ -1,0 +1,253 @@
+# APIcast-Operator Community Release
+
+[Introduction](#introduction)  
+[Main Steps Briefly](#main-steps-briefly)  
+[Versioning Strategy](#versioning-strategy)  
+[Steps to Perform Community Release in apicast-operator repo](#steps-to-perform-community-release-in-3scale-operator-repo)  
+[Prepare release in community-operators-prod repo](#prepare-release-in-community-operators-prod-repo)
+[References](#references)
+
+
+## Introduction
+* Community Release is primarily created in parallel with minor or patch Product Releases, but a major community may also be released.
+  * Community Release is not required for every productized build or every product patch release.
+* Community release can be released after downstream release
+* Community Release codebase is defined by Tag in the [apicast-operator](https://github.com/3scale/apicast-operator) repository. 
+Tag format as v\<major>.\<minor>.<build#> (for example: v0.6.0, v0.7.1)
+* Community Release bundles are defined in `redhat-openshift-ecosystem` in [apicast-community-operator repo](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/apicast-community-operator) . 
+
+
+## Main Steps Briefly
+
+Below are briefly the main steps for prepare Community Release
+
+### APIcast
+- Determine which APIcast image you want to use in the new apicast-operator Community release.
+Examples of APIcast images in apicast-operator Community releases:
+```asciidoc
+apicast-operator    APIcast image
+v0.5.0              quay.io/3scale/apicast:v3.11.0
+v0.6.0              quay.io/3scale/apicast:v3.12.0
+v0.7.1              quay.io/3scale/apicast:v3.13.2
+v0.8.0              quay.io/3scale/apicast:3scale-2.14.1-GA
+```
+
+
+### APIcast operator
+* Create Community Release Tag - apply tag to the **3scale-2.X-stable** branch to the CommitID of the base Product Release.
+  * Tag creation will trigger CircleCI build that will create Operator release Image in this [repo](https://quay.io/repository/3scale/apicast-operator?tab=tags)
+* Create a community release development branch in **apicast-operator** repo, based on the Product release CommitID, same CommitID as for Tag,
+  or, if Product release tag is not yet available, - based on **3scale-2.X-stable** branch. Do development.
+* Create PR from community release development branch to a `3scale-2.X-stable` branch (PR example: https://github.com/3scale/apicast-operator/pull/226)
+* Do Development, Test and Merge PR to `3scale-2.X-stable` branch
+* Testing - Following Testing will be done before PR merge:
+  * Fresh install
+  * Upgrade from previous release
+* Prepare Community release - create PR in **community-operators-prod** repo (based on manifests from **apicast-operator** repo), 
+as in [PR example - apicast-community-operator (0.7.1)](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/2382)
+  * **Merge of this PR will publish Release**.
+* Do sanity test of the Release after publishing
+  * Fresh install
+  * Upgrade from previous release
+
+## Versioning Strategy
+Semantic Versioning scheme will be used for Community releases:  MAJOR.MINOR.PATCH.
+* MAJOR version: Increments when breaking changes are introduced
+* MINOR version: Increments when backward-compatible functionality is added.
+* PATCH version: Increments when backward-compatible bug fixes are made.
+* APIcast ooperator Community releases Versions examples:  0.6.0,  0.7.1,  0.8.0
+* The Version is used in Community releases Tag name
+
+```shell
+$ git tag |grep -E "0.6|0.7"     
+v0.6.0
+v0.7.0
+v0.7.1
+```
+
+* Tag should be signed. Example of signed tag:
+```  
+ git show v0.7.1
+tag v0.7.1
+Tagger: Eguzki Astiz Lezaun <eastizle@redhat.com>
+Date:   Tue Mar 14 10:46:34 2023 +0100
+
+v0.7.1
+-----BEGIN PGP SIGNATURE-----
+xxxxx
+xxxxx
+-----END PGP SIGNATURE-----
+
+commit 4f3a2e26fa4e97f28cd0d276dc5d46261354afd4 (tag: v0.7.1, tag: show, tag: 3scale-2.13.2-GA, tag: 3scale-2.13.1-GA)
+.....
+```
+
+## Steps to Perform Community Release in 3scale-operator repo
+
+1. **Release Tag**
+
+- Create Community Release Tag - apply tag to the **3scale-2.X-stable** branch to the CommitID of the base Product Release.
+- Tag should be **signed**
+- Tag Name will be according to Versioning scheme and have prefix "v", like v0.8.0
+  - This tag name convention is required for triggering  of the Release Image creation in repository: 
+    https://quay.io/repository/3scale/apicast-operator?tab=tags&tag=v0.8.0
+
+Below is example of Tag creation
+  - Look for required CommitID:
+```sh
+$ cd apicast-operator
+$ git switch 3scale-2.14-stable
+
+$ git log
+commit f5b5b4b84ce02245cf5787785575546800c02a31 (HEAD -> 3scale-2.14-stable, tag: 3scale-2.14.1-GA, tag: 2.14.1, origin/3scale-2.14-stable)
+.....
+```
+- Create **signed** tag
+```sh
+$ git tag -s v0.8.0 f5b5b4b84ce02245cf5787785575546800c02a31 -m "Community Release v0.8.0"
+```
+  _Please note that you will need GPG key to create signed tag (not describe in this doc)_
+
+  - Check tag
+```sh
+$ git show v0.8.0
+tag v0.8.0
+Tagger: <user name> <user mail>
+Date:   Wed Oct 9 08:47:18 2024 +0300
+
+Community Release v0.8.0
+-----BEGIN PGP SIGNATURE-----
+XXXXXXX
+```
+
+  - Push tag to remote repository
+    - Before pushing the Tag - be sure that GPG key that you used to sign the tag is available in your GitHub account / Settings/ GPG keys.
+      This will enable GitHub to recognize tags signed with this key as **Verified**.
+
+```shell
+$ git push origin v0.8.0
+```
+  - After tag pushing: check in GitHub that tag is present and has "Verified" badge.
+
+2. **Image creation**
+- Image creation process will be triggered after applying the Tag. Image will be created automatically in
+  https://quay.io/repository/3scale/apicast-operator repository.
+- If the image is not created -
+  - check the [apicast-operator CircleCI Pipeline Builds](https://app.circleci.com/pipelines/github/3scale/apicast-operator),
+    find your build (by tag), investigate issue, create PR to fix it.
+  - after fixing and PR merge - delete the tag and create a signed tag again. Recheck CircleCI Pipeline ...
+
+3. **Community Release Development Branch**
+
+* Create a Community release development branch from **3scale-2.X-stable** branch **based on Product Release CommitID**
+  **Note**: same CommitID as for Community Release Tag
+```
+$ cd apicast-operator
+$ git switch 3scale-2.14-stable
+Switched to branch '3scale-2.14-stable'
+$ git log
+commit f5b5b4b84ce02245cf5787785575546800c02a31 (HEAD -> 3scale-2.14-stable, tag: 3scale-2.14.1-GA, tag: 2.14.1, origin/3scale-2.14-stable)
+```
+```
+$ git checkout -b apicast-community-v0.8.0 f5b5b4b84ce02245cf5787785575546800c02a31
+```
+
+4. **APIcast Components Images - APIcast**
+* Community release can use its own APIcast image or use existing build of APIcast. 
+  You can search [APIcast repository](https://github.com/3scale/APIcast) for APIcast version and Tag to be used
+  in Community APIcast operator. For example: tag: 3scale-2.14.1-GA, tag: v3.14.0 ...
+
+
+5. **Create PR for apicast-operator Community release development branch**
+   * Work on PR to have E2E tests passed
+   * Test fresh Install and Upgrade
+   * Merge PR to **3scale-2.X-stable** branch
+   * [Example of the PR, for Community release v0.8.0](https://github.com/3scale/apicast-operator/pull/228)
+  
+
+6. **Testing**
+
+   * Testing of `apicast-operator` release development PR must be completed before open PR in `community-operators-prod` repo.
+   * Testing must be done for `Fresh Install` and `Upgrade`.
+
+## Prepare release in community-operators-prod repo
+See Documentation in [Pull Requests in community operators project](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-via-pr.md)
+
+**IMPORTANT. All previouse steps, including Testing of apicast-operator (Fresh install and Upgrade) must be completed 
+  before opening a PR in the community-operators-prod repo**
+
+* Fork & Clone community-operators-prod repo if you don't have it yet
+* Get latest changes
+
+```
+$ git clone git@github.com:redhat-openshift-ecosystem/community-operators-prod.git
+$ cd community-operators-prod
+
+Example for myfork:
+$ git remote -v
+myfork        git@github.com:valerymo/community-operators-prod.git (fetch)
+myfork        git@github.com:valerymo/community-operators-prod.git (push)
+origin        git@github.com:redhat-openshift-ecosystem/community-operators-prod.git (fetch)
+origin        git@github.com:redhat-openshift-ecosystem/community-operators-prod.git (push)
+```
+
+* Create branch in community-operators-prod repo
+```
+$ git checkout -b apicast-community-operator-v0.8.0
+```
+
+* Create a new release folder (similar to previous release)
+```
+community-operators-prod/operators/apicast-community-operator/0.8.0
+```
+
+* Copy manifests from apicast-operator Community release to community-operators-prod, as for example From  [apicast-operator PR](https://github.com/3scale/apicast-operator/pull/226) To [community-operators-prod/operators/apicast-community-operator/0.8.0](community-operators-prod/operators/apicast-community-operator/0.8.0)
+
+* Update CSV. These are things that need pay attention:
+  *  apicast-operator containerImage
+  *  apicast image
+  *  CVS version
+  *  CSV replaces
+  *  CSV name
+  *  CSV description
+  *  CSV urls
+  *  Annotations
+  * * Update metadata/annotations  and bundle.Dockerfile
+  
+
+* Compare apicast-community-operator bundle with previous version, and with apicast-operator
+* Finally you will have update release bundle structure.
+* Commit your changes and Create PR 
+  * Do Signed-off  - git commit -s … , It’s required for PR test Pipeline
+
+```
+[community-operators-prod] (apicast-community-operator-v0.8.0)$ git log
+commit xxxxxxxxxxxx (HEAD -> apicast-community-operator-v0.8.0)
+Author: xxx xxx <xxx@xxx.com>
+Date:   xxx
+apicast-community-operator release v0.8.0
+Signed-off-by: xxx xxx <xxx@xxx.com>
+```
+
+```
+$ git push -u myfork apicast-community-operator-v0.8.0
+To github.com:valerymo/community-operators-prod.git
+....
+```
+
+**IMPORTANT. Merging of community-operators-prod PR will trigger Release creation/publishing**
+
+* Check and confirm all questions in PR description
+* Merge
+* Test of created release in OSD cluster / OperatorHub
+________________
+
+
+## References
+
+* [Community operators project documentation](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-via-pr.md)
+* [Community operators repository](https://github.com/k8s-operatorhub/community-operators)
+* [K8S PR example](https://github.com/k8s-operatorhub/community-operators/pull/2472)
+* [OCP PR example](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/2382)
+* *Check for the latest guidelines about what it needs to be done; they change from time to time*
+  * *Community operator release process moved* [here - operator-release-process](https://github.com/operator-framework/community-operators/blob/master/docs/operator-release-process.md)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-11385

* This PR is for validation of Community Release v0.8.0
* PR also includes new document - process of Community release creation  

* [Image](quay.io/3scale/apicast-operator:v0.8.0) was created (not part of the PR, see doc in changes) 

* Community Operator release will be created in [Community operator PR](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/5232)

* Validation done for fresh install and Upgrade

### Validation - fresh install
<details>

#### Prerequisites, Useful links
- Doc: [Apicast-operator quickstart-guide](https://github.com/3scale/apicast-operator/blob/master/doc/quickstart-guide.md)
- Install 3scale-operator (can be locall installation)
  3scale systemp-seed secret data will be used to create a secret for apicast that contains a 3scale Porta admin portal endpoint information

```sh
cd 3scale-operator
make install
export NAMESPACE=3scale-test
oc new-project $NAMESPACE
oc project $NAMESPACE
make download
make run

--------
$ oc project
Using project "3scale-test" on server "https://api.vmo01.mjhc.s1.devshift.org:6443".
$ oc apply -f s3-creds-secret.yaml 
secret/s3-credentials created
$ oc apply -f apimanagerCR.yaml   
apimanager.apps.3scale.net/example-apimanager created
```

#### Create CatalogSource

CatalogSource.yaml 

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: communityapicast
  namespace: openshift-marketplace
spec:
  displayName: Community Apicast 0.8.0
  sourceType: grpc
  image: quay.io/vmogilev_rhmi/apicast-operator-index:v0.8.0
```

```sh
oc apply -f CatalogSource.yaml 
catalogsource.operators.coreos.com/communityapicast created
```

### Install Apicast
- Install Apicast Operator from Operators Hub

```sh
$ oc get deploy
NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
apicast-operator-controller-manager-v2   1/1     1            1           22s
$ oc describe deploy apicast-operator-controller-manager-v2 |grep Image
                    containerImage: quay.io/vmogilev_rhmi/apicast-operator:v0.8.0
    Image:      quay.io/vmogilev_rhmi/apicast-operator:v0.8.0
$ oc get pod
NAME                                                      READY   STATUS    RESTARTS   AGE
apicast-operator-controller-manager-v2-5bd6876657-8vr65   1/1     Running   0          54s
$ 
```

- Create a kubernetes secret that contains a 3scale Porta admin portal endpoint information
`kubectl create secret generic ${SOME_SECRET_NAME} --from-literal=AdminPortalURL=MY_3SCALE_URL`

```
$ oc create secret generic 3scaleportal --from-literal=AdminPortalURL=https://XXXXX@3scale-admin.apps.vmo01.mjhc.s1.devshift.org

secret/3scaleportal created
```
- Apply Apicast CR
```yaml
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: apicast-test
spec:
  adminPortalCredentialsRef:
    name: 3scaleportal
  hpa: true
```

```sh
$ oc apply -f  APIcastCR.yml
apicast.apps.3scale.net/example-apicast created
```

- Check APIcast
```sh
$ oc get pod
NAME                                                      READY   STATUS    RESTARTS   AGE
apicast-example-apicast-78bd4db9c7-bzns5                  1/1     Running   0          61s
apicast-operator-controller-manager-v2-5bd6876657-8vr65   1/1     Running   0          9m22s


$ oc describe pod apicast-example-apicast-78bd4db9c7-bzns5 |grep Image:
    Image:          quay.io/3scale/apicast:3scale-2.14.1-GA


$ oc rsh apicast-example-apicast-78bd4db9c7-bzns5
sh-4.4$ ls
app  bin  http.d  lib  scripts	src
sh-4.4$ ls -l scripts/
total 16
-rwxr-xr-x. 1 default root 2866 Mar  5  2024 apicast
-rwxr-xr-x. 1 default root 1571 Mar  5  2024 apicast_cli.lua
-rwxr-xr-x. 1 default root   22 Mar  5  2024 container-entrypoint
-rwxr-xr-x. 1 default root  363 Mar  5  2024 run
sh-4.4$ 

sh-4.4$ uname -a
Linux apicast-example-apicast-78bd4db9c7-bzns5 5.14.0-427.37.1.el9_4.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Sep 13 12:41:50 EDT 2024 x86_64 x86_64 x86_64 GNU/Linux

sh-4.4$ scripts/run
loading production environment configuration: /opt/app-root/src/config/production.lua
2024/10/07 07:52:48 [emerg] 90#90: bind() to 0.0.0.0:8090 failed (98: Address already in use)
2024/10/07 07:52:48 [emerg] 90#90: bind() to 0.0.0.0:8081 failed (98: Address already in use)
......

```

</details>

### Validation - Upgrade
 
<details>
- Intall apicast-operator Release v0.7.1

```sh
$ oc get pod
NAME                                                     READY   STATUS    RESTARTS   AGE
apicast-example-apicast-85fddcbf5c-h6l5w                 1/1     Running   0          110s
apicast-operator-controller-manager-v2-dcddbd6b6-8v74t   1/1     Running   0          2m46s
$
$ oc describe pod apicast-example-apicast-85fddcbf5c-h6l5w |grep Image: 
    Image:          quay.io/3scale/apicast:v3.13.2
$ oc describe pod apicast-operator-controller-manager-v2-dcddbd6b6-8v74t |grep Image:
                  containerImage: quay.io/vmogilev_rhmi/apicast-operator:v0.7.1
    Image:         quay.io/vmogilev_rhmi/apicast-operator:v0.7.1

$ oc rsh apicast-example-apicast-85fddcbf5c-h6l5w
sh-4.4$ ls
app  bin  http.d  scripts  src
sh-4.4$ ./scripts/apicast --help 
Usage: ./scripts/apicast start ([-b] | [-l]) ([-v] | [-q])
       [--template <template>] [-3 <channel>] [-e <environment>]
       [--development] [-t] [--debug] [-c <configuration>] [-d]
       [-w <workers>] [-p <pid>] [-s <signal>] [-i <refresh_interval>]
       [--policy-load-path <policy_load_path>]
       [--log-level <log_level>] [--log-file <log_file>]
       [--access-log-file <access_log_file>] [-h] [-m [<master>]]

Start APIcast
Options:
.....
```

####  Update to Release v0.8.0

- Update Catalog source - 
      replace quay.io/vmogilev_rhmi/apicast-operator-index:v0.7.1 to v0.8.0

- Check installation
    - in Cluster portal/OperatorHub/Installed Operators - we see that APIcast operator was updated.
![image](https://github.com/user-attachments/assets/d7e4df96-d9f9-4b23-be3e-87c4853804d0)
 
   - check pods:

```sh
~/go/apicast-operator oc get pod
NAME                                                      READY   STATUS    RESTARTS   AGE
apicast-example-apicast-6b6d564684-dkrjt                  1/1     Running   0          105s
apicast-operator-controller-manager-v2-54ffd79b49-t9jsm   1/1     Running   0          2m6s
~/go/apicast-operator oc describe pod apicast-operator-controller-manager-v2-54ffd79b49-t9jsm |grep Image:
                  containerImage: quay.io/vmogilev_rhmi/apicast-operator:v0.8.0
    Image:         quay.io/vmogilev_rhmi/apicast-operator:v0.8.0
~/go/apicast-operator oc describe pod apicast-example-apicast-6b6d564684-dkrjt |grep Image:
    Image:          quay.io/3scale/apicast:3scale-2.14.1-GA
~/go/apicast-operator 
```
we see that both apicast and apicast-operators are updated

```sh
$ oc rsh apicast-example-apicast-6b6d564684-dkrjt
sh-4.4$ 
sh-4.4$ 
sh-4.4$ ls
app  bin  http.d  lib  scripts	src
sh-4.4$ ls scripts
apicast  apicast_cli.lua  container-entrypoint	run
sh-4.4$ ./scripts/apicast --help 
Usage: ./scripts/apicast start ([-b] | [-l]) ([-v] | [-q])
       [--template <template>] [-3 <channel>] [-e <environment>]
       [--development] [-t] [--debug] [-c <configuration>] [-d]
       [-w <workers>] [-p <pid>] [-s <signal>] [-i <refresh_interval>]
       [--policy-load-path <policy_load_path>]
       [--log-level <log_level>] [--log-file <log_file>]
       [--access-log-file <access_log_file>] [-h] [-m [<master>]]

Start APIcast

Options:
.....

``` 
</details>