### PR TITLE
THREESCALE-11203 Fix watched secrets logic

### DIFF
--- a/controllers/apps/apicast_controller_opentelemetry_test.go
+++ b/controllers/apps/apicast_controller_opentelemetry_test.go
@@ -173,6 +173,9 @@ func testCreateAPIcastOtelConfigurationSecret(ctx context.Context, namespace str
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testAPIcastOtelSecretName,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"apicast.apps.3scale.net/watched-by": "apicast",
+			},
 		},
 		StringData: map[string]string{
 			"otel.json": testAPIcastOtelConfig(),

--- a/controllers/apps/apicast_controller_test.go
+++ b/controllers/apps/apicast_controller_test.go
@@ -182,6 +182,9 @@ func testCreateAPIcastEmbeddedConfigurationSecret(ctx context.Context, namespace
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testAPIcastEmbeddedConfigurationSecretName,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"apicast.apps.3scale.net/watched-by": "apicast",
+			},
 		},
 		StringData: map[string]string{
 			"config.json": embeddedConfigurationContent,

--- a/pkg/apicast/apicast_option_provider.go
+++ b/pkg/apicast/apicast_option_provider.go
@@ -268,11 +268,11 @@ func (a *APIcastOptionsProvider) additionalPodAnnotations() map[string]string {
 		annotations[GatewayConfigurationSecretResverAnnotation] = a.APIcastOptions.GatewayConfigurationSecret.ResourceVersion
 	}
 
-	if a.APIcastOptions.HTTPSCertificateSecret != nil && k8sutils.IsSecretWatchedByApicast(client, a.APIcastOptions.GatewayConfigurationSecret.Name, apicastNamespace) {
+	if a.APIcastOptions.HTTPSCertificateSecret != nil && k8sutils.IsSecretWatchedByApicast(client, a.APIcastOptions.HTTPSCertificateSecret.Name, apicastNamespace) {
 		annotations[HttpsCertSecretResverAnnotation] = a.APIcastOptions.HTTPSCertificateSecret.ResourceVersion
 	}
 
-	if a.APIcastOptions.TracingConfig.Enabled && a.APIcastOptions.TracingConfig.Secret != nil && k8sutils.IsSecretWatchedByApicast(client, a.APIcastOptions.GatewayConfigurationSecret.Name, apicastNamespace) {
+	if a.APIcastOptions.TracingConfig.Enabled && a.APIcastOptions.TracingConfig.Secret != nil && k8sutils.IsSecretWatchedByApicast(client, a.APIcastOptions.TracingConfig.Secret.Name, apicastNamespace) {
 		annotations[OpenTracingSecretResverAnnotation] = a.APIcastOptions.TracingConfig.Secret.ResourceVersion
 	}
 

--- a/pkg/k8sutils/secret.go
+++ b/pkg/k8sutils/secret.go
@@ -1,7 +1,10 @@
 package k8sutils
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -16,4 +19,27 @@ func SecretStringDataFromData(secret *v1.Secret) map[string]string {
 		stringData[k] = string(v)
 	}
 	return stringData
+}
+
+func IsSecretWatchedByApicast(client k8sclient.Client, secretName, secretNamespace string) bool {
+	secret := &v1.Secret{}
+	objKey := k8sclient.ObjectKey{
+		Name:      secretName,
+		Namespace: secretNamespace,
+	}
+
+	err := client.Get(context.TODO(), objKey, secret)
+	if err != nil {
+		return false
+	}
+
+	existingLabels := secret.Labels
+
+	if existingLabels != nil {
+		if _, ok := existingLabels["apicast.apps.3scale.net/watched-by"]; ok {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/k8sutils/secret_test.go
+++ b/pkg/k8sutils/secret_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package k8sutils
 
 import (

--- a/pkg/k8sutils/secret_test.go
+++ b/pkg/k8sutils/secret_test.go
@@ -1,0 +1,74 @@
+package k8sutils
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsSecretWatchedByApicast(t *testing.T) {
+	labeledSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeled-secret",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"apicast.apps.3scale.net/watched-by": "apicast",
+			},
+		},
+	}
+	unlabeledSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-secret",
+			Namespace: "test-namespace",
+		},
+	}
+
+	type args struct {
+		client          k8sclient.Client
+		secretName      string
+		secretNamespace string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Secret doesn't have watched-by label",
+			args: args{
+				client:          fake.NewFakeClient(unlabeledSecret),
+				secretName:      "unlabeled-secret",
+				secretNamespace: "test-namespace",
+			},
+			want: false,
+		},
+		{
+			name: "Secret has watched-by label",
+			args: args{
+				client:          fake.NewFakeClient(labeledSecret),
+				secretName:      "labeled-secret",
+				secretNamespace: "test-namespace",
+			},
+			want: true,
+		},
+		{
+			name: "Secret doesn't exist",
+			args: args{
+				client:          fake.NewFakeClient(),
+				secretName:      "unlabeled-secret",
+				secretNamespace: "test-namespace",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSecretWatchedByApicast(tt.args.client, tt.args.secretName, tt.args.secretNamespace); got != tt.want {
+				t.Errorf("IsSecretWatchedByApicast() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-11203](https://issues.redhat.com/browse/THREESCALE-11203)

# What
This PR fixes the watched secrets logic so the operator will only annotate the apicast Pod and label the APIcast CR with the Secret's resourceVersion if the Secret has the `"apicast.apps.3scale.net/watched-by=apicast"` label. 

Previously, if a Secret was referenced in the APIcast CR (for example at `.spec.embeddedConfigurationSecretRef`), the operator would annotate the apicast Pod and label the APIcast CR with that Secret's resourceVersion regardless of whether or not the Secret actually had the watched-by label.

# Verification Steps
## Scenario 1: Unlabeled Secret
1. Checkout this PR
2. Prepare the cluster for a local install:
```bash
make download
make install
```
3. Create a Namespace and the configuration Secret:
```bash
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```

4. Create a custom environment Secret (without the watched-by label):
```bash
cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: custom-env-1
  namespace: $NAMESPACE
type: Opaque
stringData:
  custom_env.lua: |
    local cjson = require('cjson')
    local PolicyChain = require('apicast.policy_chain')
    local policy_chain = context.policy_chain
    
    local logging_policy_config = cjson.decode([[
    {
      "enable_access_logs": false,
      "custom_logging": "\"{{request}}\" to service {{service.name}} and {{service.id}}"
    }
    ]])
    
    policy_chain:insert( PolicyChain.load_policy('logging', 'builtin', logging_policy_config), 1)
    
    return {
      policy_chain = policy_chain,
      port = { metrics = 9421 },
    }
EOF
```

5. Create an APIcast CR that references the `custom-env-1` Secret:
```bash
cat << EOF | oc create -f -
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
  customEnvironments:
    - secretRef:
        name: custom-env-1
EOF
```

6. Run the operator:
```bash
make run
```

7. Wait for APIcast to be ready:
```bash
oc get deployment apicast-example-apicast -oyaml | yq '.status'
```

8. Verify the APIcast CR doesn't have a label for the `custom-env-1` Secret:
```bash
oc get apicast example-apicast -oyaml | yq '.metadata.labels' | grep secret.apicast.apps.3scale.net
```

9. Verify the apicast Pod doesn't have an annotation for the `custom-env-1` Secret:
```bash
oc get pod -oyaml | yq '.items[0].metadata.annotations' | grep custom-env-1
```

10. Make a change to the `custom-env-1` Secret:
```bash
oc label secret custom-env-1 foo=bar
```

11. Verify that a new apicast Pod isn't created:
```bash
oc get pods
```

## Scenario 2: Labeled Secret
1. Label the `custom-env-1` Secret with the watched-by label:
```bash
oc label secret custom-env-1 apicast.apps.3scale.net/watched-by=apicast
```

2. Force the operator to enter the reconcile loop by making a change to the APIcast CR. **NOTE:** You can also just stop the operator locally and re-run it:
```bash
oc annotate apicast example-apicast foo=bar
```

3. Verify a new Pod is created and wait for it to report as Ready:
```bash
oc get pods -w
```

4. Verify the APIcast CR has a label for the `custom-env-1` Secret:
```bash
oc get apicast example-apicast -oyaml | yq '.metadata.labels' | grep secret.apicast.apps.3scale.net
```

5. Verify the apicast Pod has the `custom-env-1` Secret annotation:
```bash
oc get pod -oyaml | yq '.items[0].metadata.annotations' | grep custom-env-1
```

6. Make a change to the `custom-env-1` Secret:
```bash
oc label secret custom-env-1 test=test
```

7. Verify that the operator recognized the change and created a new pod:
```bash
oc get pods
```

8. Verify that the new pod's annotations contains the new resourceVersion for the `custom-env-1` Secret:
```bash
oc get secret custom-env-1 -oyaml | yq '.metadata.resourceVersion'
oc get pod -oyaml | yq '.items[0].metadata.annotations' | grep custom-env-1
```