### PR TITLE
update Circleci ubuntu and ruby images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
 
   license-check:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6
     steps:
       - go/install:
           version: 1.19.10
@@ -61,7 +61,7 @@ jobs:
 
   tag-operator-image-master:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -89,7 +89,7 @@ jobs:
 
   tag-operator-image-release:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -118,7 +118,7 @@ jobs:
             make test-unit
   run-integration-test:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - go/install:


### PR DESCRIPTION
What
Jira: https://issues.redhat.com/browse/THREESCALE-11385

circleci machine image ubuntu-2004:202201-02 is being deprecated https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

Current PR is intended to update ubuntu image for circleci on 3scale-2.14-stable branch, and  fix [Community Release v0.8.0  Image  creation fail in CircleCI](https://app.circleci.com/pipelines/github/3scale/apicast-operator/973/workflows/aecce993-6154-4d17-8d8c-a1d2036f1362/jobs/4757)   . 

Similar PR was for master: https://github.com/3scale/apicast-operator/pull/222


Validation after PR Merge , as part of Jira #THREESCALE-11385:
- Recreate Community Release Tag (signed tag) v0.8.0
- Check [CircleCI pipeline build](https://app.circleci.com/pipelines/github/3scale/apicast-operator)
-  Check that Image created: quay.io/3scale/apicast-operator:v0.8.0




