### PR TITLE
THREESCALE-11396 Improved secret watched-by logic

### DIFF
--- a/apis/apps/v1alpha1/apicast_types.go
+++ b/apis/apps/v1alpha1/apicast_types.go
@@ -466,3 +466,91 @@ func (a *APIcast) Validate() field.ErrorList {
 func init() {
 	SchemeBuilder.Register(&APIcast{}, &APIcastList{})
 }
+
+func (a *APIcast) GetAdminPortalCredentialsSecretRef() *v1.LocalObjectReference {
+	return a.Spec.AdminPortalCredentialsRef
+}
+
+func (a *APIcast) GetEmbeddedConfigurationSecretRef() *v1.LocalObjectReference {
+	return a.Spec.EmbeddedConfigurationSecretRef
+}
+
+func (a *APIcast) GetOpenTelemetrySecretRef() *v1.LocalObjectReference {
+	if a.Spec.OpenTelemetry == nil {
+		return nil
+	}
+	return a.Spec.OpenTelemetry.TracingConfigSecretRef
+}
+
+func (a *APIcast) GetOpenTracingSecretRef() *v1.LocalObjectReference {
+	if a.Spec.OpenTracing == nil {
+		return nil
+	}
+	return a.Spec.OpenTracing.TracingConfigSecretRef
+}
+
+func (a *APIcast) GetCustomEnvironmentsSecretRefs() []*v1.LocalObjectReference {
+	if a.Spec.CustomEnvironments == nil {
+		return nil
+	}
+
+	secretRefs := []*v1.LocalObjectReference{}
+	for _, env := range a.Spec.CustomEnvironments {
+		if env.SecretRef != nil {
+			secretRefs = append(secretRefs, env.SecretRef)
+		}
+	}
+
+	return secretRefs
+}
+
+func (a *APIcast) GetCustomPoliciesSecretRefs() []*v1.LocalObjectReference {
+	if a.Spec.CustomPolicies == nil {
+		return nil
+	}
+
+	secretRefs := []*v1.LocalObjectReference{}
+	for _, policy := range a.Spec.CustomPolicies {
+		if policy.SecretRef != nil {
+			secretRefs = append(secretRefs, policy.SecretRef)
+		}
+	}
+
+	return secretRefs
+}
+
+func (a *APIcast) GetApicastSecretRefs() []*v1.LocalObjectReference {
+	secretRefs := []*v1.LocalObjectReference{}
+
+	adminPortalCredentialsSecretRef := a.GetAdminPortalCredentialsSecretRef()
+	if adminPortalCredentialsSecretRef != nil {
+		secretRefs = append(secretRefs, adminPortalCredentialsSecretRef)
+	}
+
+	embeddedConfigurationSecretRef := a.GetEmbeddedConfigurationSecretRef()
+	if embeddedConfigurationSecretRef != nil {
+		secretRefs = append(secretRefs, embeddedConfigurationSecretRef)
+	}
+
+	openTelemetrySecretRef := a.GetOpenTelemetrySecretRef()
+	if openTelemetrySecretRef != nil {
+		secretRefs = append(secretRefs, openTelemetrySecretRef)
+	}
+
+	opentracingSecretRef := a.GetOpenTracingSecretRef()
+	if opentracingSecretRef != nil {
+		secretRefs = append(secretRefs, opentracingSecretRef)
+	}
+
+	customEnvironmentSecretRefs := a.GetCustomEnvironmentsSecretRefs()
+	if customEnvironmentSecretRefs != nil && len(customEnvironmentSecretRefs) > 0 {
+		secretRefs = append(secretRefs, customEnvironmentSecretRefs...)
+	}
+
+	customPoliciesSecretRefs := a.GetCustomPoliciesSecretRefs()
+	if customPoliciesSecretRefs != nil && len(customPoliciesSecretRefs) > 0 {
+		secretRefs = append(secretRefs, customPoliciesSecretRefs...)
+	}
+
+	return secretRefs
+}

--- a/apis/apps/v1alpha1/apicast_types.go
+++ b/apis/apps/v1alpha1/apicast_types.go
@@ -543,12 +543,12 @@ func (a *APIcast) GetApicastSecretRefs() []*v1.LocalObjectReference {
 	}
 
 	customEnvironmentSecretRefs := a.GetCustomEnvironmentsSecretRefs()
-	if customEnvironmentSecretRefs != nil && len(customEnvironmentSecretRefs) > 0 {
+	if len(customEnvironmentSecretRefs) > 0 {
 		secretRefs = append(secretRefs, customEnvironmentSecretRefs...)
 	}
 
 	customPoliciesSecretRefs := a.GetCustomPoliciesSecretRefs()
-	if customPoliciesSecretRefs != nil && len(customPoliciesSecretRefs) > 0 {
+	if len(customPoliciesSecretRefs) > 0 {
 		secretRefs = append(secretRefs, customPoliciesSecretRefs...)
 	}
 

--- a/controllers/apps/apicast_controller_deployment_upgrade.go
+++ b/controllers/apps/apicast_controller_deployment_upgrade.go
@@ -41,7 +41,10 @@ func (r *APIcastLogicReconciler) upgradeDeploymentSelector(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 
-	expectedDeployment := apicastFactory.Deployment()
+	expectedDeployment, err := apicastFactory.Deployment(ctx, r.Client())
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	existingDeployment := &appsv1.Deployment{}
 	err = r.Client().Get(ctx, client.ObjectKeyFromObject(expectedDeployment), existingDeployment)
 	if err != nil && !errors.IsNotFound(err) {

--- a/controllers/apps/apicast_controller_deployment_upgrade_test.go
+++ b/controllers/apps/apicast_controller_deployment_upgrade_test.go
@@ -62,7 +62,9 @@ var _ = Describe("APIcast v0.6.0 deployment upgrade procedure", func() {
 
 			// v0.6.0 deployment selector
 			fmt.Fprintf(GinkgoWriter, "create old deployment for namespace '%s'\n", testNamespace)
-			apicastDeployment := apicastFactory.Deployment().DeepCopy()
+			apicastDeployment, err := apicastFactory.Deployment(context.TODO(), testClient())
+			Expect(err).ToNot(HaveOccurred())
+			apicastDeployment = apicastDeployment.DeepCopy()
 			apicastDeployment.OwnerReferences = nil
 			apicastDeployment.Spec.Selector.MatchLabels["rht.comp_ver"] = "v0.6.0"
 			apicastDeployment.Spec.Template.Labels["rht.comp_ver"] = "v0.6.0"
@@ -95,7 +97,8 @@ var _ = Describe("APIcast v0.6.0 deployment upgrade procedure", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// deployment selector should be the current one
-			newApicastDeployment := apicastFactory.Deployment()
+			newApicastDeployment, err := apicastFactory.Deployment(context.TODO(), testClient())
+			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				existingDeployment := &appsv1.Deployment{}
 				err := testClient().Get(context.TODO(), client.ObjectKey{

--- a/controllers/apps/apicast_logic_reconciler.go
+++ b/controllers/apps/apicast_logic_reconciler.go
@@ -103,6 +103,7 @@ func (r *APIcastLogicReconciler) Reconcile(ctx context.Context) (reconcile.Resul
 	}
 	secret, err := apicastFactory.HashedSecret(ctx, r.Client(), r.APIcastCR.GetApicastSecretRefs())
 	if err != nil {
+		logger.Error(err, "failed to create hashed-secret-data secret")
 		return reconcile.Result{}, err
 	}
 	err = r.ReconcileResource(ctx, &v1.Secret{}, secret, reconcilers.SecretMutator(secretMutators...))

--- a/controllers/apps/apicast_logic_reconciler.go
+++ b/controllers/apps/apicast_logic_reconciler.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -85,8 +86,26 @@ func (r *APIcastLogicReconciler) Reconcile(ctx context.Context) (reconcile.Resul
 		reconcilers.DeploymentTemplateLabelsMutator,
 	)
 
-	deployment := apicastFactory.Deployment()
+	deployment, err := apicastFactory.Deployment(ctx, r.Client())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	err = r.ReconcileResource(ctx, &appsv1.Deployment{}, deployment, reconcilers.DeploymentMutator(deploymentMutators...))
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	//
+	// Hashed Secret
+	//
+	secretMutators := []reconcilers.SecretMutateFn{
+		reconcilers.SecretStringDataMutator,
+	}
+	secret, err := apicastFactory.HashedSecret(ctx, r.Client(), r.APIcastCR.GetApicastSecretRefs())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	err = r.ReconcileResource(ctx, &v1.Secret{}, secret, reconcilers.SecretMutator(secretMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -169,7 +188,7 @@ func (r *APIcastLogicReconciler) reconcileApicastSecretLabels(ctx context.Contex
 	return replaceAPIcastSecretLabels(r.APIcastCR, secretUIDs), nil
 }
 
-func (r *APIcastLogicReconciler) getSecretUIDs(ctx context.Context) ([]string, error) {
+func (r *APIcastLogicReconciler) getSecretUIDs(ctx context.Context) (map[string]string, error) {
 	// https certificate secret
 	// admin portal secret
 	// gateway conf secret
@@ -226,19 +245,21 @@ func (r *APIcastLogicReconciler) getSecretUIDs(ctx context.Context) ([]string, e
 		})
 	}
 
-	uids := []string{}
+	uidMap := map[string]string{}
 	for idx := range secretKeys {
 		secret := &v1.Secret{}
 		secretKey := secretKeys[idx]
 		err := r.Client().Get(ctx, secretKey, secret)
-		r.Logger().V(1).Info("read secret", "objectKey", secretKey, "error", err)
+		r.Logger().V(1).Info("reading secret", "objectKey", secretKey, "error", err)
 		if err != nil {
 			return nil, err
 		}
-		uids = append(uids, string(secret.GetUID()))
+
+		watchedByVal := fmt.Sprintf("%t", k8sutils.IsSecretWatchedByApicast(secret))
+		uidMap[string(secret.GetUID())] = watchedByVal
 	}
 
-	return uids, nil
+	return uidMap, nil
 }
 
 func (r *APIcastLogicReconciler) reconcileIngress(ctx context.Context, desired *networkingv1.Ingress) error {

--- a/controllers/apps/apicast_utils.go
+++ b/controllers/apps/apicast_utils.go
@@ -10,14 +10,13 @@ import (
 
 const (
 	APIcastSecretLabelPrefix = "secret.apicast.apps.3scale.net/"
-	APIcastSecretLabelValue  = "true"
 )
 
 func apicastSecretLabelKey(uid string) string {
 	return fmt.Sprintf("%s%s", APIcastSecretLabelPrefix, uid)
 }
 
-func replaceAPIcastSecretLabels(apicast *appsv1alpha1.APIcast, desiredSecretUIDs []string) bool {
+func replaceAPIcastSecretLabels(apicast *appsv1alpha1.APIcast, desiredSecretUIDs map[string]string) bool {
 	existingLabels := apicast.GetLabels()
 
 	if existingLabels == nil {
@@ -27,18 +26,18 @@ func replaceAPIcastSecretLabels(apicast *appsv1alpha1.APIcast, desiredSecretUIDs
 	existingSecretLabels := map[string]string{}
 
 	// existing Secret UIDs not included in desiredAPIUIDs are deleted
-	for k := range existingLabels {
-		if strings.HasPrefix(k, APIcastSecretLabelPrefix) {
-			existingSecretLabels[k] = APIcastSecretLabelValue
+	for key, value := range existingLabels {
+		if strings.HasPrefix(key, APIcastSecretLabelPrefix) {
+			existingSecretLabels[key] = value
 			// it is safe to remove keys while looping in range
-			delete(existingLabels, k)
+			delete(existingLabels, key)
 		}
 	}
 
 	desiredSecretLabels := map[string]string{}
-	for _, uid := range desiredSecretUIDs {
-		desiredSecretLabels[apicastSecretLabelKey(uid)] = APIcastSecretLabelValue
-		existingLabels[apicastSecretLabelKey(uid)] = APIcastSecretLabelValue
+	for uid, watchedByStatus := range desiredSecretUIDs {
+		desiredSecretLabels[apicastSecretLabelKey(uid)] = watchedByStatus
+		existingLabels[apicastSecretLabelKey(uid)] = watchedByStatus
 	}
 
 	apicast.SetLabels(existingLabels)

--- a/doc/development.md
+++ b/doc/development.md
@@ -17,6 +17,7 @@
   * [Push an operator bundle into an external container repository](#push-an-operator-bundle-into-an-external-container-repository)
 * [Licenses management](#licenses-management)
   * [Manually adding a new license](#manually-adding-a-new-license)
+* [Adding new watched secrets](#adding-new-watched-secrets)
 
 ## Prerequisites
 
@@ -214,3 +215,16 @@ license_finder approval add github.com/golang/glog --decisions-file=doc/dependen
 [go]:https://golang.org/
 [kubernetes]:https://kubernetes.io/
 [kubectl]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+
+## Adding new watched secrets
+After adding a new secret to the APIcast CRD make sure to also update the following files if you want the apicast-operator to watch the new secret:
+1. [apis/apps/v1alpha1/apicast_types.go](../apis/apps/v1alpha1/apicast_types.go)
+   - Add a new `GetXYZSecretRef()` function that returns the secret ref
+2. [apis/apps/v1alpha1/apicast_types.go](../apis/apps/v1alpha1/apicast_types.go)
+   - Update the `GetApicastSecretRefs()` to call the new `GetXYZSecretRef()` function from step 1
+3. [pkg/apicast/apicast.go](../pkg/apicast/apicast.go) 
+   - Add the new secret to the `getWatchedSecretAnnotations()` function
+4. [pkg/apicast/apicast.go](../pkg/apicast/apicast.go)
+   - Add the new secret to the switch in the `hasSecretHashChanged()` function
+5. [pkg/apicast/apicast_option_provider.go](../pkg/apicast/apicast_option_provider.go)
+   - Add a new const called `XYZSecretResverAnnotation` that can be referenced throughout the code

--- a/pkg/apicast/apicast.go
+++ b/pkg/apicast/apicast.go
@@ -2,8 +2,11 @@ package apicast
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -14,7 +17,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +48,10 @@ const (
 const (
 	OpentelemetryConfigurationVolumeName = "otel-volume"
 	OpentelemetryConfigMountBasePath     = "/opt/app-root/src/otel-configs"
+)
+
+const (
+	HashedSecretName = "hashed-secret-data"
 )
 
 type APIcast struct {
@@ -370,7 +377,12 @@ func (a *APIcast) deploymentEnv() []v1.EnvVar {
 	return env
 }
 
-func (a *APIcast) Deployment() *appsv1.Deployment {
+func (a *APIcast) Deployment(ctx context.Context, k8sclient client.Client) (*appsv1.Deployment, error) {
+	watchedSecretAnnotations, err := a.computeWatchedSecretAnnotations(ctx, k8sclient)
+	if err != nil {
+		return nil, err
+	}
+
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -391,7 +403,7 @@ func (a *APIcast) Deployment() *appsv1.Deployment {
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      a.options.PodTemplateLabels,
-					Annotations: a.podAnnotations(),
+					Annotations: a.podAnnotations(watchedSecretAnnotations),
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: a.options.ServiceAccountName,
@@ -422,16 +434,119 @@ func (a *APIcast) Deployment() *appsv1.Deployment {
 	}
 
 	addOwnerRefToObject(deployment, *a.options.Owner)
-	return deployment
+	return deployment, nil
 }
 
-func (a *APIcast) podAnnotations() map[string]string {
+func (a *APIcast) computeWatchedSecretAnnotations(ctx context.Context, k8sclient client.Client) (map[string]string, error) {
+	// First get the initial annotations
+	uncheckedAnnotations := a.getWatchedSecretAnnotations()
+
+	// Then get the deployment (if it exists) to compare the existing annotations
+	deployment := &appsv1.Deployment{}
+	deploymentKey := client.ObjectKey{
+		Name:      a.options.DeploymentName,
+		Namespace: a.options.Namespace,
+	}
+	err := k8sclient.Get(ctx, deploymentKey, deployment)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	// If the deployment doesn't exist yet then just return the uncheckedAnnotations because there's nothing to compare to
+	if apierrors.IsNotFound(err) {
+		return uncheckedAnnotations, nil
+	}
+
+	// Next get the master hashed secret (if it exists) to compare the secret hashes
+	hashedSecret := &v1.Secret{}
+	hashedSecretKey := client.ObjectKey{
+		Name:      HashedSecretName,
+		Namespace: a.options.Namespace,
+	}
+	err = k8sclient.Get(ctx, hashedSecretKey, hashedSecret)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	// If the master hashed secret doesn't exist yet then just return the uncheckedAnnotations because there's nothing to compare to
+	if apierrors.IsNotFound(err) {
+		return uncheckedAnnotations, nil
+	}
+
+	existingPodAnnotations := deployment.Spec.Template.Annotations
+
+	// First check if the annotations match, if they do then there's no need to check the hash
+	if !reflect.DeepEqual(existingPodAnnotations, uncheckedAnnotations) {
+		reconciledAnnotations := map[string]string{}
+
+		// Loop through the annotations to see if the secret data has actually changed
+		for key, resourceVersion := range uncheckedAnnotations {
+			if existingPodAnnotations[key] == "" {
+				reconciledAnnotations[key] = resourceVersion // If this is the first time adding the annotation then use the new resourceVersion
+			} else if existingPodAnnotations[key] != resourceVersion && a.hasSecretHashChanged(ctx, k8sclient, key, hashedSecret) {
+				reconciledAnnotations[key] = resourceVersion // Else if the resourceVersions don't match and the hash has changed then use the new resourceVersion
+			} else {
+				reconciledAnnotations[key] = existingPodAnnotations[key] // Otherwise keep the existing resourceVersion
+			}
+		}
+
+		return reconciledAnnotations, nil
+	}
+	return uncheckedAnnotations, nil // No difference with existing annotations so can return uncheckedAnnotations
+}
+
+func (a *APIcast) getWatchedSecretAnnotations() map[string]string {
+	// https certificate secret
+	// admin portal secret
+	// gateway conf secret
+	// custom policy secret(s)
+	// custom env secret(s)
+	// tracing config secret
+
+	annotations := map[string]string{}
+
+	if a.options.AdminPortalCredentialsSecret != nil && k8sutils.IsSecretWatchedByApicast(a.options.AdminPortalCredentialsSecret) {
+		annotations[AdmPortalSecretResverAnnotation] = a.options.AdminPortalCredentialsSecret.ResourceVersion
+	}
+
+	if a.options.GatewayConfigurationSecret != nil && k8sutils.IsSecretWatchedByApicast(a.options.GatewayConfigurationSecret) {
+		annotations[GatewayConfigurationSecretResverAnnotation] = a.options.GatewayConfigurationSecret.ResourceVersion
+	}
+
+	if a.options.HTTPSCertificateSecret != nil && k8sutils.IsSecretWatchedByApicast(a.options.HTTPSCertificateSecret) {
+		annotations[HttpsCertSecretResverAnnotation] = a.options.HTTPSCertificateSecret.ResourceVersion
+	}
+
+	if a.options.TracingConfig.Enabled && a.options.TracingConfig.Secret != nil && k8sutils.IsSecretWatchedByApicast(a.options.TracingConfig.Secret) {
+		annotations[OpenTracingSecretResverAnnotation] = a.options.TracingConfig.Secret.ResourceVersion
+	}
+
+	for idx := range a.options.CustomEnvironments {
+		// Secrets must exist and have the watched-by label
+		// Annotation key includes the name of the secret
+		if k8sutils.IsSecretWatchedByApicast(a.options.CustomEnvironments[idx]) {
+			annotationKey := fmt.Sprintf("%s%s", CustomEnvSecretResverAnnotationPrefix, a.options.CustomEnvironments[idx].Name)
+			annotations[annotationKey] = a.options.CustomEnvironments[idx].ResourceVersion
+		}
+	}
+
+	for idx := range a.options.CustomPolicies {
+		// Secrets must exist and have the watched-by label
+		// Annotation key includes the name of the secret
+		if k8sutils.IsSecretWatchedByApicast(a.options.CustomPolicies[idx].Secret) {
+			annotationKey := fmt.Sprintf("%s%s", CustomPoliciesSecretResverAnnotationPrefix, a.options.CustomPolicies[idx].Secret.Name)
+			annotations[annotationKey] = a.options.CustomPolicies[idx].Secret.ResourceVersion
+		}
+	}
+
+	return annotations
+}
+
+func (a *APIcast) podAnnotations(watchedSecretAnnotations map[string]string) map[string]string {
 	annotations := map[string]string{
 		"prometheus.io/scrape": "true",
 		"prometheus.io/port":   "9421",
 	}
 
-	for key, val := range a.options.AdditionalPodAnnotations {
+	for key, val := range watchedSecretAnnotations {
 		annotations[key] = val
 	}
 
@@ -557,6 +672,100 @@ func (a *APIcast) Ingress() *networkingv1.Ingress {
 
 	addOwnerRefToObject(ingress, *a.options.Owner)
 	return ingress
+}
+
+func (a *APIcast) HashedSecret(ctx context.Context, k8sclient client.Client, secretRefs []*v1.LocalObjectReference) (*v1.Secret, error) {
+	hashedSecretData, err := a.computeHashedSecretData(ctx, k8sclient, secretRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HashedSecretName,
+			Namespace: a.options.Namespace,
+			Labels:    a.options.CommonLabels,
+		},
+		StringData: hashedSecretData,
+		Type:       v1.SecretTypeOpaque,
+	}, nil
+}
+
+func (a *APIcast) computeHashedSecretData(ctx context.Context, k8sclient client.Client, secretRefs []*v1.LocalObjectReference) (map[string]string, error) {
+	data := make(map[string]string)
+
+	for _, secretRef := range secretRefs {
+		secret := &v1.Secret{}
+		key := client.ObjectKey{
+			Name:      secretRef.Name,
+			Namespace: a.options.Namespace,
+		}
+		err := k8sclient.Get(ctx, key, secret)
+		if err != nil {
+			return nil, err
+		}
+
+		if k8sutils.IsSecretWatchedByApicast(secret) {
+			data[secretRef.Name] = HashSecret(secret.Data)
+		}
+	}
+
+	return data, nil
+}
+
+func HashSecret(data map[string][]byte) string {
+	hash := sha256.New()
+
+	for key, value := range data {
+		combinedKeyValue := append([]byte(key), value...)
+		hash.Write(combinedKeyValue)
+	}
+
+	hashBytes := hash.Sum(nil)
+
+	return hex.EncodeToString(hashBytes)
+}
+
+func (a *APIcast) hasSecretHashChanged(ctx context.Context, k8sclient client.Client, deploymentAnnotation string, hashedSecret *v1.Secret) bool {
+	secretToCheck := &v1.Secret{}
+	secretToCheckKey := client.ObjectKey{
+		Namespace: a.options.Namespace,
+	}
+
+	// Assign the name of the secret to check
+	switch {
+	case deploymentAnnotation == AdmPortalSecretResverAnnotation:
+		secretToCheckKey.Name = a.options.AdminPortalCredentialsSecret.Name
+	case deploymentAnnotation == GatewayConfigurationSecretResverAnnotation:
+		secretToCheckKey.Name = a.options.GatewayConfigurationSecret.Name
+	case deploymentAnnotation == HttpsCertSecretResverAnnotation:
+		secretToCheckKey.Name = a.options.HTTPSCertificateSecret.Name
+	case deploymentAnnotation == OpenTracingSecretResverAnnotation:
+		secretToCheckKey.Name = a.options.TracingConfig.Secret.Name
+	case strings.HasPrefix(deploymentAnnotation, CustomEnvSecretResverAnnotationPrefix):
+		secretToCheckKey.Name = strings.TrimPrefix(deploymentAnnotation, CustomEnvSecretResverAnnotationPrefix)
+	case strings.HasPrefix(deploymentAnnotation, CustomPoliciesSecretResverAnnotationPrefix):
+		secretToCheckKey.Name = strings.TrimPrefix(deploymentAnnotation, CustomPoliciesSecretResverAnnotationPrefix)
+	default:
+		return false
+	}
+
+	// Get latest version of the secret to check
+	err := k8sclient.Get(ctx, secretToCheckKey, secretToCheck)
+	if err != nil {
+		return false
+	}
+
+	// Compare the hash of the latest version of the secret's data to the reference in the hashed secret
+	if HashSecret(secretToCheck.Data) != k8sutils.SecretStringDataFromData(hashedSecret)[secretToCheckKey.Name] {
+		return true
+	}
+
+	return false
 }
 
 func addOwnerRefToObject(o metav1.Object, owner metav1.OwnerReference) {

--- a/pkg/apicast/apicast_option_provider.go
+++ b/pkg/apicast/apicast_option_provider.go
@@ -197,9 +197,6 @@ func (a *APIcastOptionsProvider) GetApicastOptions(ctx context.Context) (*APIcas
 	}
 	a.APIcastOptions.TracingConfig = tracingOptions
 
-	// Annotations from user secrets. Used to rollout apicast deployment if any secrets changes
-	a.APIcastOptions.AdditionalPodAnnotations = a.additionalPodAnnotations()
-
 	//
 	otelConfig, err := a.getOpenTelemetryConfig(ctx)
 	if err != nil {
@@ -245,49 +242,6 @@ func (a *APIcastOptionsProvider) getTracingConfigOptions(ctx context.Context) (T
 	}
 
 	return res, nil
-}
-
-func (a *APIcastOptionsProvider) additionalPodAnnotations() map[string]string {
-	// https certificate secret
-	// admin portal secret
-	// gateway conf secret
-	// custom policy secret(s)
-	// custom env secret(s)
-	// tracing config secret
-
-	annotations := map[string]string{}
-
-	if a.APIcastOptions.AdminPortalCredentialsSecret != nil {
-		annotations[AdmPortalSecretResverAnnotation] = a.APIcastOptions.AdminPortalCredentialsSecret.ResourceVersion
-	}
-
-	if a.APIcastOptions.GatewayConfigurationSecret != nil {
-		annotations[GatewayConfigurationSecretResverAnnotation] = a.APIcastOptions.GatewayConfigurationSecret.ResourceVersion
-	}
-
-	if a.APIcastOptions.HTTPSCertificateSecret != nil {
-		annotations[HttpsCertSecretResverAnnotation] = a.APIcastOptions.HTTPSCertificateSecret.ResourceVersion
-	}
-
-	if a.APIcastOptions.TracingConfig.Enabled && a.APIcastOptions.TracingConfig.Secret != nil {
-		annotations[OpenTracingSecretResverAnnotation] = a.APIcastOptions.TracingConfig.Secret.ResourceVersion
-	}
-
-	for idx := range a.APIcastOptions.CustomEnvironments {
-		// Secrets must exist
-		// Annotation key includes the name of the secret
-		annotationKey := fmt.Sprintf("%s%s", CustomEnvSecretResverAnnotationPrefix, a.APIcastOptions.CustomEnvironments[idx].Name)
-		annotations[annotationKey] = a.APIcastOptions.CustomEnvironments[idx].ResourceVersion
-	}
-
-	for idx := range a.APIcastOptions.CustomPolicies {
-		// Secrets must exist
-		// Annotation key includes the name of the secret
-		annotationKey := fmt.Sprintf("%s%s", CustomPoliciesSecretResverAnnotationPrefix, a.APIcastOptions.CustomPolicies[idx].Secret.Name)
-		annotations[annotationKey] = a.APIcastOptions.CustomPolicies[idx].Secret.ResourceVersion
-	}
-
-	return annotations
 }
 
 func (a *APIcastOptionsProvider) getGatewayEmbeddedConfigSecret(ctx context.Context) (*v1.Secret, error) {

--- a/pkg/apicast/apicast_option_provider.go
+++ b/pkg/apicast/apicast_option_provider.go
@@ -23,6 +23,7 @@ const (
 	GatewayConfigurationSecretResverAnnotation = "apicast.apps.3scale.net/gateway-configuration-secret-resource-version"
 	HttpsCertSecretResverAnnotation            = "apicast.apps.3scale.net/https-cert-secret-resource-version"
 	OpenTracingSecretResverAnnotation          = "apicast.apps.3scale.net/opentracing-secret-resource-version"
+	OpenTelemetrySecretResverAnnotation        = "apicast.apps.3scale.net/opentelemetry-secret-resource-version"
 	CustomEnvSecretResverAnnotationPrefix      = "apicast.apps.3scale.net/customenv-secret-resource-version-"
 	CustomPoliciesSecretResverAnnotationPrefix = "apicast.apps.3scale.net/custompolicy-secret-resource-version-"
 	APPLABEL                                   = "apicast"

--- a/pkg/apicast/apicast_options.go
+++ b/pkg/apicast/apicast_options.go
@@ -37,7 +37,6 @@ type APIcastOptions struct {
 	Owner                        *metav1.OwnerReference `validate:"required"`
 	ServiceName                  string                 `validate:"required"`
 	Replicas                     int32
-	AdditionalPodAnnotations     map[string]string       `validate:"required"`
 	ServiceAccountName           string                  `validate:"required"`
 	Image                        string                  `validate:"required"`
 	ExposedHost                  ExposedHost             `validate:"-"`

--- a/pkg/apicast/apicast_test.go
+++ b/pkg/apicast/apicast_test.go
@@ -3,20 +3,29 @@
 package apicast
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace                              = "my-namespace"
+	testAPIcastEmbeddedConfigurationSecretName = "apicast-embedded-configuration"
+	testCustomEnvironmentSecretName            = "custom-env-1"
 )
 
 func testDefaultOpts() *APIcastOptions {
 	opts := NewAPIcastOptions()
-	opts.Namespace = "my-namespace"
+	opts.Namespace = testNamespace
 	opts.DeploymentName = "apicast-apicast1"
 	opts.Owner = &metav1.OwnerReference{}
 	opts.ServiceName = "apicast-apicast1"
-	opts.AdditionalPodAnnotations = map[string]string{}
 	opts.ServiceAccountName = "my-sa"
 	opts.Image = "example.com/my-registry/apicast-operator:latest"
 	opts.AdminPortalCredentialsSecret = &v1.Secret{}
@@ -40,7 +49,10 @@ func TestAPIcastDeploymentSelector(t *testing.T) {
 		t.Errorf("validation error: %v", err)
 	}
 	apicastFactory := NewAPIcast(opts)
-	deployment := apicastFactory.Deployment()
+	deployment, err := apicastFactory.Deployment(context.TODO(), fake.NewFakeClient())
+	if err != nil {
+		t.Errorf("error getting deployment: %v", err)
+	}
 	if deployment == nil {
 		t.Error("deployment is nil")
 	}
@@ -51,4 +63,180 @@ func TestAPIcastDeploymentSelector(t *testing.T) {
 	if !reflect.DeepEqual(podLabelSelector, deployment.Spec.Selector.MatchLabels) {
 		t.Error("deployment selector does not match podlabelselector")
 	}
+}
+
+func TestAPIcast_HashedSecret(t *testing.T) {
+	secrets := []runtime.Object{testAPIcastEmbeddedConfigurationSecret(), testCustomEnvironmentSecret()}
+	secretRefs := []*v1.LocalObjectReference{
+		{
+			Name: testAPIcastEmbeddedConfigurationSecretName,
+		},
+		{
+			Name: testCustomEnvironmentSecretName,
+		},
+	}
+
+	type args struct {
+		ctx        context.Context
+		k8sclient  client.Client
+		secretRefs []*v1.LocalObjectReference
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *v1.Secret
+		wantErr bool
+	}{
+		{
+			name: "succesfully create empty hashed secret",
+			args: args{
+				ctx:        context.TODO(),
+				k8sclient:  fake.NewFakeClient(secrets...),
+				secretRefs: make([]*v1.LocalObjectReference, 0),
+			},
+			want: &v1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      HashedSecretName,
+					Namespace: testDefaultOpts().Namespace,
+					Labels:    testDefaultOpts().CommonLabels,
+				},
+				StringData: map[string]string{},
+				Type:       v1.SecretTypeOpaque,
+			},
+			wantErr: false,
+		},
+		{
+			name: "successfully create filled hashed secret",
+			args: args{
+				ctx:        context.TODO(),
+				k8sclient:  fake.NewFakeClient(secrets...),
+				secretRefs: secretRefs,
+			},
+			want: &v1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      HashedSecretName,
+					Namespace: testDefaultOpts().Namespace,
+					Labels:    testDefaultOpts().CommonLabels,
+				},
+				StringData: map[string]string{
+					testAPIcastEmbeddedConfigurationSecretName: "aeefb14e2600c4b611b71955d84f3f79db8a399ea092a7baaed922ab37f95012",
+					testCustomEnvironmentSecretName:            "a37c48fa15cb1fe1d8b656fc385899664c7ff23b99d95d53c7784daefef9656b",
+				},
+				Type: v1.SecretTypeOpaque,
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail to create hashed secret if missing source secrets",
+			args: args{
+				ctx:        context.TODO(),
+				k8sclient:  fake.NewFakeClient(),
+				secretRefs: secretRefs,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &APIcast{
+				options: testDefaultOpts(),
+			}
+			got, err := a.HashedSecret(tt.args.ctx, tt.args.k8sclient, tt.args.secretRefs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HashedSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("HashedSecret() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testAPIcastEmbeddedConfigurationSecret() *v1.Secret {
+	embeddedConfigurationContent := `{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration": {
+              "rules": [{
+                "regex": "/",
+                "url": "http://echo-api.3scale.net"
+              }]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}`
+	embeddedConfigSecret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testAPIcastEmbeddedConfigurationSecretName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				"apicast.apps.3scale.net/watched-by": "apicast",
+			},
+		},
+		Data: map[string][]byte{
+			"config.json": []byte(embeddedConfigurationContent),
+		},
+	}
+
+	return &embeddedConfigSecret
+}
+
+func testCustomEnvironmentSecret() *v1.Secret {
+	customEnvironmentContent := `
+    local cjson = require('cjson')
+    local PolicyChain = require('apicast.policy_chain')
+    local policy_chain = context.policy_chain
+    
+    local logging_policy_config = cjson.decode([[
+    {
+      "enable_access_logs": false,
+      "custom_logging": "\"{{request}}\" to service {{service.name}} and {{service.id}}"
+    }
+    ]])
+    
+    policy_chain:insert( PolicyChain.load_policy('logging', 'builtin', logging_policy_config), 1)
+    
+    return {
+      policy_chain = policy_chain,
+      port = { metrics = 9421 },
+    }
+`
+	customEnvironmentSecret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCustomEnvironmentSecretName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				"apicast.apps.3scale.net/watched-by": "apicast",
+			},
+		},
+		Data: map[string][]byte{
+			"custom_env.lua": []byte(customEnvironmentContent),
+		},
+	}
+
+	return &customEnvironmentSecret
 }

--- a/pkg/k8sutils/secret.go
+++ b/pkg/k8sutils/secret.go
@@ -17,3 +17,19 @@ func SecretStringDataFromData(secret *v1.Secret) map[string]string {
 	}
 	return stringData
 }
+
+func IsSecretWatchedByApicast(secret *v1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+
+	existingLabels := secret.Labels
+
+	if existingLabels != nil {
+		if _, ok := existingLabels["apicast.apps.3scale.net/watched-by"]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/k8sutils/secret_test.go
+++ b/pkg/k8sutils/secret_test.go
@@ -1,0 +1,66 @@
+//go:build unit
+
+package k8sutils
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsSecretWatchedByApicast(t *testing.T) {
+	labeledSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeled-secret",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"apicast.apps.3scale.net/watched-by": "apicast",
+			},
+		},
+	}
+	unlabeledSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-secret",
+			Namespace: "test-namespace",
+		},
+	}
+
+	type args struct {
+		secret *v1.Secret
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Secret doesn't have watched-by label",
+			args: args{
+				secret: unlabeledSecret,
+			},
+			want: false,
+		},
+		{
+			name: "Secret has watched-by label",
+			args: args{
+				secret: labeledSecret,
+			},
+			want: true,
+		},
+		{
+			name: "Secret doesn't exist",
+			args: args{
+				secret: nil,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSecretWatchedByApicast(tt.args.secret); got != tt.want {
+				t.Errorf("IsSecretWatchedByApicast() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconcilers/secret.go
+++ b/pkg/reconcilers/secret.go
@@ -1,0 +1,53 @@
+package reconcilers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/3scale/apicast-operator/pkg/k8sutils"
+	v1 "k8s.io/api/core/v1"
+)
+
+// SecretMutateFn is a function which mutates the existing Secret into it's desired state.
+type SecretMutateFn func(desired, existing *v1.Secret) bool
+
+func SecretMutator(opts ...SecretMutateFn) MutateFn {
+	return func(existingObj, desiredObj k8sutils.KubernetesObject) (bool, error) {
+		existing, ok := existingObj.(*v1.Secret)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.Secret", existingObj)
+		}
+		desired, ok := desiredObj.(*v1.Secret)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.Secret", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate := opt(desired, existing)
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
+func SecretStringDataMutator(desired, existing *v1.Secret) bool {
+	updated := false
+
+	// StringData is merged to Data on write, so we need to compare the existing Data to the desired StringData
+	// Before we can do this we need to convert the existing Data to StringData
+	existingStringData := make(map[string]string)
+	for key, bytes := range existing.Data {
+		existingStringData[key] = string(bytes)
+	}
+	if !reflect.DeepEqual(existingStringData, desired.StringData) {
+		updated = true
+		existing.Data = nil // Need to clear the existing.Data because of how StringData is converted to Data
+		existing.StringData = desired.StringData
+	}
+
+	return updated
+}


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-11396](https://issues.redhat.com/browse/THREESCALE-11396)

# What
This PR improves on the existing secret watched-by logic in a few ways:

1. Previously the secret labels on the APIcast CR followed this pattern: `secret.apicast.apps.3scale.net/{secret-UID: 'true'`, where the value was set to `true` regardless of whether the secret had the `watched-by` label. Now the value is set to `false` if the Secret doesn't have the `watched-by` label and `true` if the secret does have the `watched-by` label.
2. Previously the operator would annotate the apicast pod with `apimanager.apps.3scale.net/{secret-name}: '{secret-resourceVersion}'` whenever a secret was referenced in the APIcast CR. Now the apicast pod is only annotated if the referenced secret _also_ has the `watched-by` label on it.
3. Previously, any and all changes to a watched secret would trigger the apicast deployment to rollout a new pod whose annotations contained the latest resourceVersion of the watched secret. Now the operator will only rollout new pods when there is a change to the secret's `.data`, i.e. changes to the watched secrets labels, annotations, etc. won't trigger a rollout even if though the secret's resourceVersion changed. This is accomplished through a new secret called `hashed-secret-data` that stores a hash of each watched secret's data using SHA256 encryption. Whenever the operator detects that a watched secret's resourceVersion has changed, it first takes a hash of the secret's current `.data` and if that matches the secret's entry in the `hashed-secret-data` secret, then the operator will ignore the change and prevent a rollout. If the `.data` has changed, the operator will update the apicast pod's annotations with the watched secret's latest resourceVersion which will trigger a rollout.

# Verification Steps
1. Checkout this PR
2. Prepare the cluster for a local install:
```bash
make download
make install
```
3. Create a Namespace and the configuration Secret:
```bash
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```

4. Create a custom environment Secret (without the watched-by label):
```bash
cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: custom-env-1
  namespace: $NAMESPACE
type: Opaque
stringData:
  custom_env.lua: |
    local cjson = require('cjson')
    local PolicyChain = require('apicast.policy_chain')
    local policy_chain = context.policy_chain
    
    local logging_policy_config = cjson.decode([[
    {
      "enable_access_logs": false,
      "custom_logging": "\"{{request}}\" to service {{service.name}} and {{service.id}}"
    }
    ]])
    
    policy_chain:insert( PolicyChain.load_policy('logging', 'builtin', logging_policy_config), 1)
    
    return {
      policy_chain = policy_chain,
      port = { metrics = 9421 },
    }
EOF
```

5. Create an APIcast CR that references the `custom-env-1` Secret:
```bash
cat << EOF | oc create -f -
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
  customEnvironments:
    - secretRef:
        name: custom-env-1
EOF
```

6. Run the operator:
```bash
make run
```

7. Wait for APIcast to be ready:
```bash
oc get deployment apicast-example-apicast -oyaml | yq '.status'
```

8. Verify that the APIcast labels reference the two secrets' UIDs but the label values are `false`:
```bash
oc get apicast example-apicast -oyaml | yq '.metadata.labels'
```
The labels should look like this:
```
secret.apicast.apps.3scale.net/86655a7f-c4bd-4d2a-b364-9fcdfe8eed96: "false"
secret.apicast.apps.3scale.net/fdb8d92d-e446-4882-aa49-569329f5712d: "false"
```

9. Verify that the apicast pod annotations don't contain references to the secrets since neither of the secrets have the `watched-by` label:
```bash
oc get pods -o yaml | yq '.items[0].metadata.annotations' | grep apicast.apps.3scale.net
```

10. Verify that the `hashed-secret-data` secret exists but is empty:
```bash
oc get secret hashed-secret-data -oyaml
```

11. Add the `watched-by` label to the configuration secret:
```bash
oc label secret apicast-config-secret apicast.apps.3scale.net/watched-by=apicast
```

12. Verify that the APIcast labels were updated and that one of secret labels has a value of `true`:
```bash
oc get apicast example-apicast -oyaml | yq '.metadata.labels'
```
The labels should now look like this:
```
secret.apicast.apps.3scale.net/86655a7f-c4bd-4d2a-b364-9fcdfe8eed96: "false"
secret.apicast.apps.3scale.net/fdb8d92d-e446-4882-aa49-569329f5712d: "true"
```

13. Once the new pod is ready, verify that it has an annotation referencing the config secret:
```bash
oc get pods -o yaml | yq '.items[0].metadata.annotations' | grep apicast.apps.3scale.net
```
There should be an annotation that looks like this:
```
apicast.apps.3scale.net/gateway-configuration-secret-resource-version: "164701"
```

14. Verify that the `hashed-secret-data` secret has an entry for the config secret:
```bash
oc get secret hashed-secret-data -oyaml
```

15. Edit the data in the config secret and verify a new pod is created:
```bash
oc get pods
```

16. Once the pods have stabilized, add a label to the config secret and verify that no new pods are created even though the resourceVersion has changed:
```bash
oc label secret apicast-config-secret dummy=label
```