### PR TITLE
THREESCALE-11013 include full 3scale version in apicast cr

### DIFF
--- a/apis/apps/v1alpha1/apicast_types.go
+++ b/apis/apps/v1alpha1/apicast_types.go
@@ -32,9 +32,10 @@ import (
 )
 
 const (
-	APIcastOperatorVersionAnnotation        = "apicast.apps.3scale.net/operator-version"
-	ReadyConditionType               string = "Ready"
-	WarningConditionType             string = "Warning"
+	APIcastOperatorVersionAnnotation          = "apicast.apps.3scale.net/operator-version"
+	APIcastThreescaleVersionAnnotation        = "apicast.apps.3scale.net/apicast-threescale-version"
+	ReadyConditionType                 string = "Ready"
+	WarningConditionType               string = "Warning"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -383,6 +384,11 @@ func (a *APIcast) UpdateOperatorVersion() bool {
 
 	if v, ok := a.Annotations[APIcastOperatorVersionAnnotation]; !ok || v != version.Version {
 		a.Annotations[APIcastOperatorVersionAnnotation] = version.Version
+		changed = true
+	}
+
+	if v, ok := a.Annotations[APIcastThreescaleVersionAnnotation]; !ok || v != version.ThreescaleVersionMajorMinorPatch() {
+		a.Annotations[APIcastThreescaleVersionAnnotation] = version.ThreescaleVersionMajorMinorPatch()
 		changed = true
 	}
 

--- a/pkg/helper/labels.go
+++ b/pkg/helper/labels.go
@@ -18,7 +18,7 @@ func MeteringLabels(componentType ComponentType) map[string]string {
 		// It should be updated on release branch
 		"rht.prod_ver":  "master",
 		"rht.comp":      "3scale_apicast",
-		"rht.comp_ver":  version.ThreescaleRelease,
+		"rht.comp_ver":  version.ThreescaleVersionMajorMinor(),
 		"rht.subcomp":   "apicast",
 		"rht.subcomp_t": string(componentType),
 	}

--- a/test/manifests-version/deployment_version_test.go
+++ b/test/manifests-version/deployment_version_test.go
@@ -55,7 +55,7 @@ func TestDeploymentVersions(t *testing.T) {
 		t.Errorf("Parsed object is not a Deployment object")
 	}
 
-	if deployment.Spec.Template.Labels["rht.comp_ver"] != version.ThreescaleRelease {
-		t.Errorf("rht.comp_ver differ: expected: %s; found: %s", version.ThreescaleRelease, deployment.Spec.Template.Labels["rht.comp_ver"])
+	if deployment.Spec.Template.Labels["rht.comp_ver"] != version.ThreescaleVersionMajorMinor() {
+		t.Errorf("rht.comp_ver differ: expected: %s; found: %s", version.ThreescaleVersionMajorMinor(), deployment.Spec.Template.Labels["rht.comp_ver"])
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,22 @@
 package version
 
+import (
+	"strings"
+)
+
 var (
 	Version           = "0.13.0"
-	ThreescaleRelease = "2.16"
+	threescaleRelease = "2.16.0"
 )
+
+func ThreescaleVersionMajorMinor() string {
+	parts := strings.Split(threescaleRelease, ".")
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return ""
+}
+
+func ThreescaleVersionMajorMinorPatch() string {
+	return threescaleRelease
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-11013

Verification:
- run `make install`
- run:
```
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```
- run
```
cat << EOF | oc create -f -
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
EOF
```
- run `make run`
- confirm that annotations are present on apicast CR:
```
apicast.apps.3scale.net/apicast-threescale-version: 2.16.0
apicast.apps.3scale.net/operator-version: 0.13.0
```    
- confirm that the deployment label rht.comp_ver is 2.16