### PR TITLE
[THREESCALE-7921] New APIcast CRD field: caCertificateSecretRef

### DIFF
--- a/apis/apps/v1alpha1/apicast_types.go
+++ b/apis/apps/v1alpha1/apicast_types.go
@@ -177,6 +177,9 @@ type APIcastSpec struct {
 	// HTTPSCertificateSecretRef references secret containing the X.509 certificate in the PEM format and the X.509 certificate secret key.
 	// +optional
 	HTTPSCertificateSecretRef *v1.LocalObjectReference `json:"httpsCertificateSecretRef,omitempty"`
+	// CACertificateSecretRef references secret containing the X.509 CA certificate in the PEM format.
+	// +optional
+	CACertificateSecretRef *v1.LocalObjectReference `json:"caCertificateSecretRef,omitempty"`
 	// Workers defines the number of APIcast's worker processes per pod.
 	// +optional
 	// +kubebuilder:validation:Minimum=1

--- a/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -253,6 +253,11 @@ func (in *APIcastSpec) DeepCopyInto(out *APIcastSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
+	if in.CACertificateSecretRef != nil {
+		in, out := &in.CACertificateSecretRef, &out.CACertificateSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.Workers != nil {
 		in, out := &in.Workers, &out.Workers
 		*out = new(int32)

--- a/bundle/manifests/apps.3scale.net_apicasts.yaml
+++ b/bundle/manifests/apps.3scale.net_apicasts.yaml
@@ -65,6 +65,17 @@ spec:
                   a protocol-specific proxy is not specified. Authentication is not supported.
                   Format is <scheme>://<host>:<port>
                 type: string
+              caCertificateSecretRef:
+                description: CACertificateSecretRef references secret containing the X.509 CA certificate in the PEM format.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               cacheConfigurationSeconds:
                 description: |-
                   The period (in seconds) that the APIcast configuration will be stored in

--- a/config/crd/bases/apps.3scale.net_apicasts.yaml
+++ b/config/crd/bases/apps.3scale.net_apicasts.yaml
@@ -58,6 +58,18 @@ spec:
                   a protocol-specific proxy is not specified. Authentication is not supported.
                   Format is <scheme>://<host>:<port>
                 type: string
+              caCertificateSecretRef:
+                description: CACertificateSecretRef references secret containing the
+                  X.509 CA certificate in the PEM format.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               cacheConfigurationSeconds:
                 description: |-
                   The period (in seconds) that the APIcast configuration will be stored in

--- a/doc/apicast-crd-reference.md
+++ b/doc/apicast-crd-reference.md
@@ -36,6 +36,7 @@
 | `httpsPort` | int | No | 8443 only when `httpsCertificateSecretRef` is provided | Controls on which port APIcast should start listening for HTTPS connections. Do not use `8080` as HTTPS port (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_https_port)) |
 | `httpsVerifyDepth` | int | No | N/A | Defines the maximum length of the client certificate chain. (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_https_verify_depth)) |
 | `httpsCertificateSecretRef` | LocalObjectReference | No | APIcast has a default certificate used when `httpsPort` is provided | References secret containing the X.509 certificate in the PEM format and the X.509 certificate secret key |
+| `caCertificateSecretRef` | LocalObjectReference | No | N/A | References secret containing the X.509 CA certificate |
 | `workers` | integer | No | Automatically computed. Check [apicast doc](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_workers) for further info. | Defines the number of worker processes |
 | `timezone` | string | No | N/A | The local timezone of the APIcast deployment pods. Its value must be a compatible value with the tz database | Defines the number of worker processes |
 | `customPolicies` | [][CustomPolicySpec](#CustomPolicySpec) | No | N/A | List of custom policies |

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -311,6 +311,37 @@ $ echo quit | openssl s_client -showcerts -connect 127.0.0.1:8443 2>/dev/null | 
 
 The downloaded certificate should match provided certificate.
 
+#### Override default CA certificate at pod level
+You can override the default CA certificate used by APIcast pod with `caCertificateSecretRef` field.
+
+Steps to override CA certificate at pod level:
+
+1.- Genrate CA certificate
+```
+openssl genrsa -out rootCA.key 2048
+openssl req -batch -new -x509 -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.pem
+```
+
+2.- Create the certificate secret
+```
+kubectl create secret generic cacert --namespace=apicast-test --from-file=ca-bundle.crt=rootCA.pem
+```
+
+3.- Reference the certificate secret in APIcast CR
+
+```
+apiVersion: apps.3scale.net/v1alpha1
+kind: APIcast
+metadata:
+  name: apicast1
+spec:
+  ...
+  caCertificateSecretRef:
+    name: cacert
+```
+
+See [APIcast CRD reference](apicast-crd-reference.md)
+
 ### Reconciliation
 After an APIcast self-managed gateway solution has been installed, APIcast
 operator enables updating a given set of parameters from the custom resource

--- a/pkg/apicast/apicast_option_provider.go
+++ b/pkg/apicast/apicast_option_provider.go
@@ -270,7 +270,6 @@ func (a *APIcastOptionsProvider) getGatewayEmbeddedConfigSecret(ctx context.Cont
 
 	gatewayConfigSecret := v1.Secret{}
 	err := a.Client.Get(ctx, gatewayConfigSecretNamespacedName, &gatewayConfigSecret)
-
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +301,6 @@ func (a *APIcastOptionsProvider) getAdminPortalCredentialsSecret(ctx context.Con
 
 	adminPortalCredentialsSecret := v1.Secret{}
 	err := a.Client.Get(ctx, adminPortalCredentialsNamespacedName, &adminPortalCredentialsSecret)
-
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +348,6 @@ func (a *APIcastOptionsProvider) getHTTPSCertificateSecret(ctx context.Context) 
 
 	secret := &v1.Secret{}
 	err := a.Client.Get(ctx, namespacedName, secret)
-
 	if err != nil {
 		// NotFoundError is also an error, it is required to exist
 		return nil, err
@@ -398,10 +395,14 @@ func (a *APIcastOptionsProvider) getCACertificateSecret(ctx context.Context) (*v
 
 	secret := &v1.Secret{}
 	err := a.Client.Get(ctx, namespacedName, secret)
-
 	if err != nil {
 		// NotFoundError is also an error, it is required to exist
 		return nil, err
+	}
+
+	if _, ok := secret.Data[CACertificatesSecretKey]; !ok {
+		errors = append(errors, field.Required(secretNameFldPath, fmt.Sprintf("Required secret key, %s not found", CACertificatesSecretKey)))
+		return nil, errors.ToAggregate()
 	}
 
 	return secret, nil
@@ -410,7 +411,6 @@ func (a *APIcastOptionsProvider) getCACertificateSecret(ctx context.Context) (*v
 func (a *APIcastOptionsProvider) validateCustomPolicySecret(ctx context.Context, nn types.NamespacedName) (*v1.Secret, error) {
 	secret := &v1.Secret{}
 	err := a.Client.Get(ctx, nn, secret)
-
 	if err != nil {
 		// NotFoundError is also an error, it is required to exist
 		return nil, err
@@ -430,7 +430,6 @@ func (a *APIcastOptionsProvider) validateCustomPolicySecret(ctx context.Context,
 func (a *APIcastOptionsProvider) customEnvSecret(ctx context.Context, nn types.NamespacedName) (*v1.Secret, error) {
 	secret := &v1.Secret{}
 	err := a.Client.Get(ctx, nn, secret)
-
 	if err != nil {
 		// NotFoundError is also an error, it is required to exist
 		return nil, err
@@ -446,7 +445,6 @@ func (a *APIcastOptionsProvider) customEnvSecret(ctx context.Context, nn types.N
 func (a *APIcastOptionsProvider) validateTracingConfigSecret(ctx context.Context, nn types.NamespacedName) (*v1.Secret, error) {
 	secret := &v1.Secret{}
 	err := a.Client.Get(ctx, nn, secret)
-
 	if err != nil {
 		// NotFoundError is also an error, it is required to exist
 		return nil, err

--- a/pkg/apicast/apicast_options.go
+++ b/pkg/apicast/apicast_options.go
@@ -66,6 +66,7 @@ type APIcastOptions struct {
 	HTTPSPort                           *int32
 	HTTPSVerifyDepth                    *int64
 	HTTPSCertificateSecret              *v1.Secret
+	CACertificateSecret                 *v1.Secret
 	Workers                             *int32
 	Timezone                            *string
 	CustomPolicies                      []CustomPolicy


### PR DESCRIPTION
## What

Fix https://issues.redhat.com/browse/THREESCALE-7921

## Verification step
* Checkout this branch

* Run
```
make install
```
* Create apicast config
```
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```
* Generate CA cert
```
openssl genrsa -out rootCA.key 2048
openssl req -batch -new -x509 -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.pem
```
* Create secret
```
oc create secret generic cacert --namespace=apicast-test --from-file=ca-bundle.crt=rootCA.pem 
```
* Create APIcast
```
cat << EOF | oc create -f -
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  caCertificateSecretRef:
    name: cacert
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
EOF
```
* Run operator locally
```
make run
```
* Wait APIcast pod comes online
* Check that the cert is mounted correctly
```
 ▲ t/fixtures/CA oc get pod                                                                                     
                       
NAME                                       READY   STATUS    RESTARTS   AGE                                     
apicast-example-apicast-666bddf8d5-nns84   0/1     Running   0          27s                                     
 ▲ t/fixtures/CA oc rsh apicast-example-apicast-666bddf8d5-nns84 cat /var/run/secrets/apicast/ca-bundle.crt     
                         
-----BEGIN CERTIFICATE-----                                                                                     
[CA certificate content]                                                   
-----END CERTIFICATE-----                                                                                       
```
* Check the env var is set correctly
```
 △ t/fixtures/CA oc rsh apicast-example-apicast-666bddf8d5-nns84 env | grep SS
SSL_CERT_FILE=/var/run/secrets/apicast/ca-bundle.crt   
```