### PR TITLE
THREESCALE-11239 Fix operator prevents oc rollout restart command

### DIFF
--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -106,16 +106,13 @@ func DeploymentResourceMutator(desired, existing *appsv1.Deployment) bool {
 	return update
 }
 
+// DeploymentPodTemplateAnnotationsMutator ensures Pod Template Annotations is reconciled
 func DeploymentPodTemplateAnnotationsMutator(desired, existing *appsv1.Deployment) bool {
 	update := false
 
-	// They are annotations of the PodTemplate, part of the Spec, not part of the meta info of the Pod or Environment object itself
-	// It is not expected any controller to update them, so we use "set" approach, instead of merge.
-	// This way any removed annotation from desired (due to change in CR) will be removed in existing too.
-	if !reflect.DeepEqual(existing.Spec.Template.Annotations, desired.Spec.Template.Annotations) {
-		update = true
-		existing.Spec.Template.Annotations = desired.Spec.Template.Annotations
-	}
+	// Use merge instead of set
+	// See THREESCALE-11239
+	k8sutils.MergeMapStringString(&update, &existing.Spec.Template.Annotations, desired.Spec.Template.Annotations)
 
 	return update
 }


### PR DESCRIPTION
## What

[THREESCALE-11239](https://issues.redhat.com/browse/THREESCALE-11239)

## Verification steps 
* Checkout this branch
* Run
```
make install
```
* Create Apicast config
```bash
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```
* Create APIcast
```bash
cat << EOF | oc create -f -
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  exposedHost:
    host: my-gateway
    ingressClassName: openshift-default
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
  priorityClassName: high-priority
EOF
```
* Run operator locally
```
make run
```
* Wait for APIcast pod to come online
* Rollout new pod
```bash
oc rollout restart deployment/apicast-example-apicast
```
* You should see a new pod is created