### PR TITLE
THREESCALE-12224 Loosen APIcast operator logic to allow custom environment variables in Deployment

### DIFF
--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -79,7 +79,7 @@ func DeploymentServiceAccountNameMutator(desired, existing *appsv1.Deployment) b
 }
 
 func DeploymentEnvVarsMutator(desired, existing *appsv1.Deployment) bool {
-	return ReconcileEnvVar(&existing.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env)
+	return ReconcileEnvVars(&existing.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env)
 }
 
 func DeploymentResourceMutator(desired, existing *appsv1.Deployment) bool {

--- a/pkg/reconcilers/envvar_reconciler.go
+++ b/pkg/reconcilers/envvar_reconciler.go
@@ -3,27 +3,59 @@ package reconcilers
 import (
 	"reflect"
 
-	"github.com/3scale/apicast-operator/pkg/k8sutils"
 	v1 "k8s.io/api/core/v1"
 )
 
-// ReconcileEnvVar reconciles environment var lists
-func ReconcileEnvVar(existing *[]v1.EnvVar, desired []v1.EnvVar) bool {
-	if *existing == nil {
-		*existing = []v1.EnvVar{}
+// ReconcileEnvVar reconciles a complete list of environment variables.
+// Added when in desired and not in existing
+// Updated when in desired and in existing but not equal
+// Removed when not in desired and exists in existing
+func ReconcileEnvVars(existing *[]v1.EnvVar, desired []v1.EnvVar) bool {
+	if existing == nil {
+		*existing = make([]v1.EnvVar, 0, len(desired))
 	}
 
-	if len(*existing) != len(desired) {
-		*existing = desired
-		return true
+	// Build maps for fast lookups
+	existingMap := make(map[string]int, len(*existing))
+	for i, ev := range *existing {
+		existingMap[ev.Name] = i
 	}
 
-	for _, desiredEnvVar := range desired {
-		if idx := k8sutils.FindEnvVar(*existing, desiredEnvVar.Name); idx < 0 || !reflect.DeepEqual((*existing)[idx], desiredEnvVar) {
-			*existing = desired
-			return true
+	desiredMap := make(map[string]v1.EnvVar, len(desired))
+	for _, ev := range desired {
+		desiredMap[ev.Name] = ev
+	}
+
+	update := false
+	result := make([]v1.EnvVar, 0, len(desired))
+
+	for _, desiredVar := range desired {
+		if existingIdx, found := existingMap[desiredVar.Name]; found {
+			// Exists - check if update needed
+			if !reflect.DeepEqual((*existing)[existingIdx], desiredVar) {
+				result = append(result, desiredVar)
+				update = true
+			} else {
+				result = append(result, (*existing)[existingIdx])
+			}
+		} else {
+			// New var - add it
+			result = append(result, desiredVar)
+			update = true
 		}
 	}
 
-	return false
+	// Check for custom vars (in existing but not in desired)
+	for _, existingVar := range *existing {
+		if _, found := desiredMap[existingVar.Name]; !found {
+			result = append(result, existingVar)
+			update = true
+		}
+	}
+
+	if update {
+		*existing = result
+	}
+
+	return update
 }

--- a/pkg/reconcilers/envvar_reconciler_test.go
+++ b/pkg/reconcilers/envvar_reconciler_test.go
@@ -1,0 +1,105 @@
+package reconcilers
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestReconcileEnvVars(t *testing.T) {
+	cases := []struct {
+		name           string
+		existing       []v1.EnvVar
+		desired        []v1.EnvVar
+		expectedResult bool
+		expectedEnvs   []v1.EnvVar
+	}{
+		{
+			name:     "Nil existing",
+			existing: nil,
+			desired: []v1.EnvVar{
+				{Name: "new_var", Value: "value"},
+			},
+			expectedResult: true,
+			expectedEnvs: []v1.EnvVar{
+				{Name: "new_var", Value: "value"},
+			},
+		},
+		{
+			name:           "No changes when empty",
+			existing:       []v1.EnvVar{},
+			desired:        []v1.EnvVar{},
+			expectedResult: false,
+			expectedEnvs:   []v1.EnvVar{},
+		},
+		{
+			name:           "No changes when identical",
+			existing:       []v1.EnvVar{{Name: "foo", Value: "bar"}},
+			desired:        []v1.EnvVar{{Name: "foo", Value: "bar"}},
+			expectedResult: false,
+			expectedEnvs:   []v1.EnvVar{{Name: "foo", Value: "bar"}},
+		},
+		{
+			name:           "Add new EnvVar",
+			existing:       []v1.EnvVar{},
+			desired:        []v1.EnvVar{{Name: "foo", Value: "bar"}},
+			expectedResult: true,
+			expectedEnvs:   []v1.EnvVar{{Name: "foo", Value: "bar"}},
+		},
+		{
+			name:           "Update existing EnvVar",
+			existing:       []v1.EnvVar{{Name: "foo", Value: "old"}},
+			desired:        []v1.EnvVar{{Name: "foo", Value: "new"}},
+			expectedResult: true,
+			expectedEnvs:   []v1.EnvVar{{Name: "foo", Value: "new"}},
+		},
+		{
+			name: "Preserve custom EnvVars",
+			existing: []v1.EnvVar{
+				{Name: "foo", Value: "bar"},
+				{Name: "custom", Value: "custom_value"},
+			},
+			desired: []v1.EnvVar{
+				{Name: "foo", Value: "bar"},
+			},
+			expectedResult: true,
+			expectedEnvs: []v1.EnvVar{
+				{Name: "foo", Value: "bar"},
+				{Name: "custom", Value: "custom_value"},
+			},
+		},
+		{
+			name: "Add and preserve",
+			existing: []v1.EnvVar{
+				{Name: "existing", Value: "old_value"},
+				{Name: "custom", Value: "custom_value"},
+			},
+			desired: []v1.EnvVar{
+				{Name: "existing", Value: "new_value"},
+				{Name: "new_var", Value: "new_value"},
+			},
+			expectedResult: true,
+			expectedEnvs: []v1.EnvVar{
+				{Name: "existing", Value: "new_value"},
+				{Name: "new_var", Value: "new_value"},
+				{Name: "custom", Value: "custom_value"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(subT *testing.T) {
+			update := ReconcileEnvVars(&tc.existing, tc.desired)
+
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+
+			// Check if the resulting env vars match expected
+			if !reflect.DeepEqual(tc.existing, tc.expectedEnvs) {
+				subT.Fatalf("env vars mismatch:\nexpected: %+v\ngot:      %+v", tc.expectedEnvs, tc.existing)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fix [THREESCALE-12224](https://issues.redhat.com/browse/THREESCALE-12224)

## Verification steps
* run `make install`
* run:
```
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```
* run
```
cat << EOF | oc create -f -
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
EOF
```
 * run `make run`
 * Update Deployment en var
```
 oc set env deployment/apicast-example-apicast Foo=bar
```
* Confirm that new pod is deployed and check the pod variable environments
* Restart the operator
```
CTRL-C
make run
```
* Confirm that the environment variable is still there.
* Remove the environment variable from Deployment and check that it has also been removed from the pod.
